### PR TITLE
Remove unnecessary permission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Change Log
+
+## 1.1.1 (2025-09-08)
+
+### Changes
+- Remove unnecessary permissions (USE_FINGERPRINT) from the manifest file.

--- a/gradle.properties
+++ b/gradle.properties
@@ -25,7 +25,7 @@ android.defaults.buildfeatures.buildconfig=true
 android.nonFinalResIds=false
 versionMajor=1
 versionMinor=1
-versionPatch=0
+versionPatch=1
 snapshotBuild=false
 
 kotlinVersion=2.0.21

--- a/webauthn/src/main/AndroidManifest.xml
+++ b/webauthn/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
-    <uses-permission android:name="android.permission.USE_FINGERPRINT" />
     <uses-permission android:name="android.permission.USE_BIOMETRIC" />
     <application>
         <activity


### PR DESCRIPTION
Since minsdk is 28, android.permission.USE_FINGERPRINT is not required.