### PR TITLE
Exclude unnecessary room dependency

### DIFF
--- a/webauthn/build.gradle
+++ b/webauthn/build.gradle
@@ -136,12 +136,6 @@ dependencies {
     // androidx biometric
     implementation "androidx.biometric:biometric:$project.biometricVersion"
 
-    // Room
-    implementation "androidx.room:room-runtime:$project.roomVersion"
-    ksp "androidx.room:room-compiler:$project.roomVersion"
-    implementation "androidx.room:room-ktx:$project.roomVersion"
-    androidTestImplementation "androidx.room:room-testing:$project.roomVersion"
-
     // serialization
     implementation "org.jetbrains.kotlinx:kotlinx-serialization-json:$project.kotlinxSerializationVersion"
 


### PR DESCRIPTION
There is no import to use androidx.room API on webauthn-kotlin.
* https://github.com/search?q=repo%3Aline%2Fwebauthn-kotlin%20androidx.room&type=code

So, this is unnecessary dependency, and needs to clean up.