### PR TITLE
1.2.0: WebAuthn wire-format, cancellation, and key-cleanup fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,46 @@
 # Change Log
 
+## 1.2.0 (2026-07-07)
+
+### Fixed
+- Fix `cleanup()` deleting a re-encoded KeyStore alias: failed or rolled-back
+  registrations left the hardware-backed private key orphaned on the device.
+- Fall back to TEE key generation when a vendor StrongBox implementation rejects
+  the request with a plain `ProviderException` (e.g. KeyMint `UNIMPLEMENTED`)
+  instead of `StrongBoxUnavailableException`.
+- Encode COSE EC2 public key coordinates as fixed-length 32-byte values
+  (previously `BigInteger.toByteArray()` produced 33- or <32-byte coordinates,
+  rejected by strict WebAuthn servers). Applies to new registrations only.
+- Emit definite-length CBOR maps for `attestationObject` and
+  `credentialPublicKey` (CTAP2 canonical form), replacing indefinite-length maps.
+- `getAllAccounts()` no longer returns each credential four times.
+- `deleteAllAccounts()` now deletes the KeyStore private keys together with the
+  DB rows.
+- Validate `user.id` as 1..64 decoded bytes per the WebAuthn spec instead of
+  string characters.
+- Match `allowCredentials` descriptors by type as well as rpId.
+- Fix ES512 curve name (`secp521r1`).
+- Run KeyStore access, key generation, and attestation/assertion creation off
+  the caller's dispatcher (ANR prevention); `BiometricPrompt` stays on Main.
+- Propagate `CancellationException` instead of wrapping it, make rollback
+  cleanup `NonCancellable`, and skip cleanup for pre-flight failures.
+- Add lifecycle (RESUMED) guards and continuation safety to all authentication
+  paths, including the API<30 KeyguardManager flow.
+- Pin the biometric prompt to `BIOMETRIC_STRONG` via `setAllowedAuthenticators`.
+- Collect a user authorization gesture before surfacing an excludeCredentials
+  match (WebAuthn L2 6.3.2 step 3), preventing silent credential probing.
+
+### Added
+- `PublicKeyCredential.canAuthenticate(context)`: pre-flight capability check
+  returning the raw `BiometricManager` status code.
+- `NotAllowedException.errorCode` / `isUserCancellation`: the BiometricPrompt
+  error code, so user cancellations can be separated from genuine failures
+  without matching localized messages.
+- `ConstraintException.capabilityStatus`: the raw `canAuthenticate()` status
+  explaining why the device is unsupported.
+- `DeletionException.trigger`: the original failure that caused the rollback.
+- `UserVerificationRequirement.DISCOURAGED`.
+
 ## 1.1.3 (2025-09-16)
 
 ### Changed

--- a/gradle.properties
+++ b/gradle.properties
@@ -68,8 +68,8 @@ ksp.useKSP2=false
 ###############################################################################
 
 versionMajor=1
-versionMinor=1
-versionPatch=3
+versionMinor=2
+versionPatch=0
 snapshotBuild=false
 
 ###############################################################################

--- a/webauthn/src/main/java/com/linecorp/webauthn/authenticator/Authenticator.kt
+++ b/webauthn/src/main/java/com/linecorp/webauthn/authenticator/Authenticator.kt
@@ -24,6 +24,8 @@ import com.linecorp.webauthn.authenticator.objectgenerator.Fido2ObjectGenerator
 import com.linecorp.webauthn.db.CredentialSourceStorage
 import com.linecorp.webauthn.exceptions.WebAuthnException
 import com.linecorp.webauthn.handler.AuthenticationHandler
+import com.linecorp.webauthn.handler.BiometricAuthenticationHandler
+import com.linecorp.webauthn.handler.DeviceCredentialAuthenticationHandler
 import com.linecorp.webauthn.model.AssertionObject
 import com.linecorp.webauthn.model.AttestationObject
 import com.linecorp.webauthn.model.AttestationStatementFormat
@@ -300,9 +302,19 @@ internal class Authenticator(
      */
     private fun checkAuthenticationSupport(context: Context) {
         if (!authenticationHandler.isSupported(context)) {
+            // Preserve the raw BiometricManager.canAuthenticate() status so callers can
+            // distinguish "nothing enrolled" from "no capable hardware" without a repro.
+            // Diagnostic lookup must never change the primary failure, hence runCatching.
+            val status: Int? = runCatching {
+                when (val handler = authenticationHandler) {
+                    is BiometricAuthenticationHandler -> handler.capabilityStatus(context)
+                    is DeviceCredentialAuthenticationHandler -> handler.capabilityStatus(context)
+                    else -> null
+                }
+            }.getOrNull()
             throw WebAuthnException.CoreException.ConstraintException(
                 message = "Authentication is not supported by a device."
-            )
+            ).apply { capabilityStatus = status }
         }
     }
 
@@ -421,12 +433,12 @@ internal class Authenticator(
             throw WebAuthnException.CoreException.NotAllowedException(
                 message = "Authentication failed",
                 cause = e
-            )
+            ).apply { errorCode = e.errorCode }
         } catch (e: AuthenticationHandler.AuthenticationErrorException) {
             throw WebAuthnException.CoreException.NotAllowedException(
                 message = "Authentication error is occurred.",
                 cause = e
-            )
+            ).apply { errorCode = e.errorCode }
         } catch (e: android.security.keystore.KeyPermanentlyInvalidatedException) {
             throw WebAuthnException.AuthenticationException.KeyPermanentlyInvalidatedException(
                 cause = e

--- a/webauthn/src/main/java/com/linecorp/webauthn/authenticator/Authenticator.kt
+++ b/webauthn/src/main/java/com/linecorp/webauthn/authenticator/Authenticator.kt
@@ -441,7 +441,10 @@ internal class Authenticator(
      * @throws WebAuthnException.CredSrcStorageException If there is an error deleting the credential from the database.
      */
     suspend fun cleanup(credId: String) {
-        val keyAlias = credId.toBase64url()
+        // The credId is already a base64url string and is used as the KeyStore alias as-is
+        // (see makeCredential/getAssertion: keyAlias = credId). Re-encoding it here would
+        // produce a different alias and silently skip deleting the actual key.
+        val keyAlias = credId
         SecureExecutionHelper.deleteKey(keyAlias)
         try {
             withContext(databaseDispatcher) {

--- a/webauthn/src/main/java/com/linecorp/webauthn/authenticator/Authenticator.kt
+++ b/webauthn/src/main/java/com/linecorp/webauthn/authenticator/Authenticator.kt
@@ -51,8 +51,10 @@ import com.linecorp.webauthn.util.base64urlToByteArray
 import com.linecorp.webauthn.util.toBase64url
 import java.security.PrivateKey
 import java.security.Signature
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.withContext
 
@@ -64,6 +66,7 @@ internal class Authenticator(
     val authType: AuthenticatorType,
     var fido2PromptInfo: Fido2PromptInfo? = null,
     val databaseDispatcher: CoroutineDispatcher = Dispatchers.IO,
+    val cryptoDispatcher: CoroutineDispatcher = Dispatchers.Default,
 ) {
 
     /**
@@ -99,7 +102,10 @@ internal class Authenticator(
         excludeCredDescriptorList: List<PublicKeyCredentialDescriptor>?,
         extensions: AuthenticatorExtensionsInput?,
     ): Result<AuthenticatorMakeCredentialResult> {
-        val (credIdBytes: ByteArray, credId: String) = generateUniqueCredId()
+        // KeyStore access and key generation are blocking binder/crypto calls; keep them
+        // off the caller's dispatcher (typically Main) to avoid ANRs.
+        val (credIdBytes: ByteArray, credId: String) = withContext(cryptoDispatcher) { generateUniqueCredId() }
+        var keyCreated = false
         try {
             val credTypeAndPubKeyAlg: PublicKeyCredentialParams = fetchCredTypeAndPubKeyAlg(credTypesAndPubKeyAlgs)
             checkCredentialWasNotRegistered(rpEntity.id, excludeCredDescriptorList)
@@ -116,12 +122,15 @@ internal class Authenticator(
 
             val fmt = authType.getAttestationStatementFormat()
             val challenge = if (fmt != AttestationStatementFormat.NONE) hash else null
-            val keyPair = fido2KeyGenerator.generateFido2Key(
-                keyAlias = keyAlias,
-                challenge = challenge,
-                publicKeyAlgorithm = credTypeAndPubKeyAlg.alg,
-                isStrongBoxBacked = isStrongBoxSupported(activity.applicationContext),
-            )
+            val keyPair = withContext(cryptoDispatcher) {
+                fido2KeyGenerator.generateFido2Key(
+                    keyAlias = keyAlias,
+                    challenge = challenge,
+                    publicKeyAlgorithm = credTypeAndPubKeyAlg.alg,
+                    isStrongBoxBacked = isStrongBoxSupported(activity.applicationContext),
+                )
+            }
+            keyCreated = true
 
             val fido2UserAuthResult = if (fmt != AttestationStatementFormat.NONE) {
                 val signatureAlgorithm = credTypeAndPubKeyAlg.alg.getSignatureAlgorithmName()
@@ -132,15 +141,17 @@ internal class Authenticator(
                 authenticate(activity, authenticationHandler, fido2PromptInfo)
             }
 
-            val attestationObject: AttestationObject = fido2ObjectGenerator.createAttestationObject(
-                hash = hash,
-                rpId = rpEntity.id,
-                aaguid = authType.aaguidBytes(),
-                credId = credId,
-                signCount = 0u,
-                extensions = AuthenticatorExtensionsOutput.getAuthenticatorExtensionResult(extensions),
-                signature = fido2UserAuthResult.signature,
-            )
+            val attestationObject: AttestationObject = withContext(cryptoDispatcher) {
+                fido2ObjectGenerator.createAttestationObject(
+                    hash = hash,
+                    rpId = rpEntity.id,
+                    aaguid = authType.aaguidBytes(),
+                    credId = credId,
+                    signCount = 0u,
+                    extensions = AuthenticatorExtensionsOutput.getAuthenticatorExtensionResult(extensions),
+                    signature = fido2UserAuthResult.signature,
+                )
+            }
 
             storeCredentialSourceIntoDB(credentialSource)
 
@@ -150,8 +161,16 @@ internal class Authenticator(
                     attestationObject = attestationObject.toCBOR(),
                 )
             )
+        } catch (e: CancellationException) {
+            // Roll back the half-created credential, then let cancellation propagate
+            // instead of being wrapped into a WebAuthnException, so structured
+            // concurrency keeps working for the caller.
+            if (keyCreated) {
+                runCatching { cleanup(credId) }
+            }
+            throw e
         } catch (e: Throwable) {
-            return handleMakeCredentialException(e, credId)
+            return handleMakeCredentialException(e, credId, keyCreated)
         }
     }
 
@@ -185,10 +204,15 @@ internal class Authenticator(
 
             checkAuthenticationSupport(activity.applicationContext)
 
-            val key = SecureExecutionHelper.getKey(keyAlias) ?: throw WebAuthnException.KeyNotFoundException(
+            // KeyStore access is a blocking binder call; keep it off the caller's dispatcher.
+            val key = withContext(cryptoDispatcher) {
+                SecureExecutionHelper.getKey(keyAlias)
+            } ?: throw WebAuthnException.KeyNotFoundException(
                 message = "Cannot get a key from device."
             )
-            val signatureAlgorithm = SecureExecutionHelper.getX509Certificate(keyAlias).sigAlgName
+            val signatureAlgorithm = withContext(cryptoDispatcher) {
+                SecureExecutionHelper.getX509Certificate(keyAlias).sigAlgName
+            }
             val fido2UserAuthResult = authenticate(activity, authenticationHandler, fido2PromptInfo) {
                 Signature.getInstance(signatureAlgorithm).apply { initSign(key as PrivateKey) }
             }
@@ -217,7 +241,7 @@ internal class Authenticator(
                 )
             }
 
-            val assertionObject: AssertionObject =
+            val assertionObject: AssertionObject = withContext(cryptoDispatcher) {
                 fido2ObjectGenerator.createAssertionObject(
                     hash = hash,
                     rpId = rpId,
@@ -225,6 +249,7 @@ internal class Authenticator(
                     signature = fido2UserAuthResult.signature!!,
                     extensions = processedExtensions
                 )
+            }
 
             return Result.success(
                 AuthenticatorGetAssertionResult(
@@ -234,6 +259,10 @@ internal class Authenticator(
                     userHandle = selectedCred.userHandle?.base64urlToByteArray(),
                 )
             )
+        } catch (e: CancellationException) {
+            // Let cancellation propagate for structured concurrency instead of
+            // converting it into a WebAuthnException failure result.
+            throw e
         } catch (e: Exception) {
             val authenticatorException = if (e is WebAuthnException) {
                 e
@@ -453,17 +482,24 @@ internal class Authenticator(
      * @throws WebAuthnException.CredSrcStorageException If there is an error deleting the credential from the database.
      */
     suspend fun cleanup(credId: String) {
-        // The credId is already a base64url string and is used as the KeyStore alias as-is
-        // (see makeCredential/getAssertion: keyAlias = credId). Re-encoding it here would
-        // produce a different alias and silently skip deleting the actual key.
-        val keyAlias = credId
-        SecureExecutionHelper.deleteKey(keyAlias)
-        try {
-            withContext(databaseDispatcher) {
-                db.delete(credId = credId)
+        // NonCancellable: this rollback must run to completion even when the calling
+        // coroutine is already cancelled, otherwise the key and the DB row can get out
+        // of sync (key deleted but row left behind, or vice versa).
+        withContext(NonCancellable) {
+            // The credId is already a base64url string and is used as the KeyStore alias
+            // as-is (see makeCredential/getAssertion: keyAlias = credId). Re-encoding it
+            // here would produce a different alias and silently skip deleting the key.
+            val keyAlias = credId
+            withContext(cryptoDispatcher) {
+                SecureExecutionHelper.deleteKey(keyAlias)
             }
-        } catch (e: Exception) {
-            throw WebAuthnException.CredSrcStorageException("Failed to delete credential for credId: $credId", e)
+            try {
+                withContext(databaseDispatcher) {
+                    db.delete(credId = credId)
+                }
+            } catch (e: Exception) {
+                throw WebAuthnException.CredSrcStorageException("Failed to delete credential for credId: $credId", e)
+            }
         }
     }
 
@@ -514,11 +550,13 @@ internal class Authenticator(
      *
      * @param e The exception that occurred.
      * @param credId The credential ID related to the exception.
+     * @param keyCreated True when a key pair was already generated for this credential.
      * @return A failure result containing the exception.
      */
     private suspend fun handleMakeCredentialException(
         e: Throwable,
-        credId: String
+        credId: String,
+        keyCreated: Boolean,
     ): Result<AuthenticatorMakeCredentialResult> {
         val authenticatorException = if (e is WebAuthnException) {
             e
@@ -527,6 +565,13 @@ internal class Authenticator(
                 message = "An unknown error occurred.",
                 cause = e
             )
+        }
+
+        if (!keyCreated) {
+            // Nothing was persisted yet: skip cleanup so a pre-flight failure (unsupported
+            // device, duplicate credential, ...) is not masked by a DeletionException from
+            // deleting state that never existed.
+            return Result.failure(authenticatorException)
         }
 
         return try {

--- a/webauthn/src/main/java/com/linecorp/webauthn/authenticator/Authenticator.kt
+++ b/webauthn/src/main/java/com/linecorp/webauthn/authenticator/Authenticator.kt
@@ -108,8 +108,18 @@ internal class Authenticator(
         var keyCreated = false
         try {
             val credTypeAndPubKeyAlg: PublicKeyCredentialParams = fetchCredTypeAndPubKeyAlg(credTypesAndPubKeyAlgs)
-            checkCredentialWasNotRegistered(rpEntity.id, excludeCredDescriptorList)
             checkAuthenticationSupport(activity.applicationContext)
+            if (findExcludedCredential(rpEntity.id, excludeCredDescriptorList) != null) {
+                // WebAuthn L2 6.3.2 step 3: collect an authorization gesture BEFORE
+                // returning InvalidStateError, so a relying party cannot silently probe
+                // whether a given credential exists on this device. If the user declines,
+                // authenticate() maps the refusal to NotAllowedException as the spec
+                // requires.
+                authenticate(activity, authenticationHandler, fido2PromptInfo)
+                throw WebAuthnException.CoreException.InvalidStateException(
+                    message = "The credential is already registered."
+                )
+            }
             val keyAlias: String = credId
 
             val credentialSource = com.linecorp.webauthn.model.PublicKeyCredentialSource(
@@ -348,18 +358,19 @@ internal class Authenticator(
     }
 
     /**
-     * Checks if a credential is not registered.
+     * Finds a credential from the exclude list that is already registered on this device.
      *
      * @param rpId The relying party ID.
      * @param excludeCredDescriptorList The list of credentials to exclude.
-     * @return True if the credential is not registered, false otherwise.
+     * @return The first matching registered credential, or null when none of the excluded
+     * credentials exist.
      */
-    private suspend fun checkCredentialWasNotRegistered(
+    private suspend fun findExcludedCredential(
         rpId: String,
         excludeCredDescriptorList: List<PublicKeyCredentialDescriptor>?,
-    ) {
+    ): PublicKeyCredentialSource? {
         if (excludeCredDescriptorList.isNullOrEmpty()) {
-            return
+            return null
         }
         for (descriptor in excludeCredDescriptorList) {
             val credentialSource = try {
@@ -377,12 +388,10 @@ internal class Authenticator(
                 credentialSource.rpId == rpId &&
                 credentialSource.type == descriptor.type
             ) {
-                throw WebAuthnException.CoreException.InvalidStateException(
-                    message = "The credential is already registered."
-                )
+                return credentialSource
             }
         }
-        return
+        return null
     }
 
     /**

--- a/webauthn/src/main/java/com/linecorp/webauthn/authenticator/Authenticator.kt
+++ b/webauthn/src/main/java/com/linecorp/webauthn/authenticator/Authenticator.kt
@@ -552,6 +552,10 @@ internal class Authenticator(
             try {
                 cleanup(credId)
                 return
+            } catch (e: CancellationException) {
+                // Coroutine cancellation is not a cleanup failure: let it propagate instead
+                // of retrying or being re-wrapped as a DeletionException by the callers.
+                throw e
             } catch (e: Throwable) {
                 if (attempt == maxTries - 1) throw e
                 delay(delayMillis)
@@ -616,6 +620,8 @@ internal class Authenticator(
         return try {
             retryCleanup(credId, maxTries = 2, delayMillis = 1000)
             Result.failure(authenticatorException)
+        } catch (e2: CancellationException) {
+            throw e2
         } catch (e2: Throwable) {
             Result.failure(
                 WebAuthnException.DeletionException(

--- a/webauthn/src/main/java/com/linecorp/webauthn/authenticator/Authenticator.kt
+++ b/webauthn/src/main/java/com/linecorp/webauthn/authenticator/Authenticator.kt
@@ -23,6 +23,8 @@ import com.linecorp.webauthn.authenticator.keygenerator.Fido2KeyGenerator
 import com.linecorp.webauthn.authenticator.objectgenerator.Fido2ObjectGenerator
 import com.linecorp.webauthn.db.CredentialSourceStorage
 import com.linecorp.webauthn.exceptions.WebAuthnException
+import com.linecorp.webauthn.exceptions.biometricManagerStatusName
+import com.linecorp.webauthn.exceptions.biometricPromptErrorName
 import com.linecorp.webauthn.handler.AuthenticationHandler
 import com.linecorp.webauthn.handler.BiometricAuthenticationHandler
 import com.linecorp.webauthn.handler.DeviceCredentialAuthenticationHandler
@@ -351,8 +353,9 @@ internal class Authenticator(
                     else -> null
                 }
             }.getOrNull()
+            val detail = status?.let { " (capabilityStatus=$it ${biometricManagerStatusName(it)})" } ?: ""
             throw WebAuthnException.CoreException.ConstraintException(
-                message = "Authentication is not supported by a device."
+                message = "Authentication is not supported by a device.$detail"
             ).apply { capabilityStatus = status }
         }
     }
@@ -470,13 +473,17 @@ internal class Authenticator(
         try {
             return authenticationHandler.authenticate(activity, fido2PromptInfo, signatureProvider)
         } catch (e: AuthenticationHandler.AuthenticationFailedException) {
+            // Keep the base message stable for log grouping; append code + constant name
+            // so services can act on the exact reason without a lookup table.
+            val detail = e.errorCode?.let { " (errorCode=$it ${biometricPromptErrorName(it)})" } ?: ""
             throw WebAuthnException.CoreException.NotAllowedException(
-                message = "Authentication failed",
+                message = "Authentication failed$detail",
                 cause = e
             ).apply { errorCode = e.errorCode }
         } catch (e: AuthenticationHandler.AuthenticationErrorException) {
+            val detail = e.errorCode?.let { " (errorCode=$it ${biometricPromptErrorName(it)})" } ?: ""
             throw WebAuthnException.CoreException.NotAllowedException(
-                message = "Authentication error is occurred.",
+                message = "Authentication error is occurred.$detail",
                 cause = e
             ).apply { errorCode = e.errorCode }
         } catch (e: android.security.keystore.KeyPermanentlyInvalidatedException) {

--- a/webauthn/src/main/java/com/linecorp/webauthn/authenticator/Authenticator.kt
+++ b/webauthn/src/main/java/com/linecorp/webauthn/authenticator/Authenticator.kt
@@ -410,7 +410,9 @@ internal class Authenticator(
                         e
                     )
                 }
-                if (credSource != null && credSource.rpId == rpId) {
+                // Match type as well as rpId, mirroring the exclude-list check
+                // (WebAuthn L2: allowCredentials entries are matched by type and id).
+                if (credSource != null && credSource.rpId == rpId && credSource.type == descriptor.type) {
                     credOptions.add(credSource)
                 }
             }

--- a/webauthn/src/main/java/com/linecorp/webauthn/authenticator/Authenticator.kt
+++ b/webauthn/src/main/java/com/linecorp/webauthn/authenticator/Authenticator.kt
@@ -140,9 +140,16 @@ internal class Authenticator(
                     challenge = challenge,
                     publicKeyAlgorithm = credTypeAndPubKeyAlg.alg,
                     isStrongBoxBacked = isStrongBoxSupported(activity.applicationContext),
-                )
+                ).also {
+                    // Set the flag INSIDE the crypto dispatcher block, right after the key
+                    // is committed to the KeyStore. withContext has a prompt-cancellation
+                    // guarantee: if the caller's job is cancelled while keygen runs, the
+                    // key is still created but withContext discards the result and throws
+                    // CancellationException. Setting the flag after the block would leave it
+                    // false, so the cancellation handler would skip cleanup and orphan the key.
+                    keyCreated = true
+                }
             }
-            keyCreated = true
 
             val fido2UserAuthResult = if (fmt != AttestationStatementFormat.NONE) {
                 val signatureAlgorithm = credTypeAndPubKeyAlg.alg.getSignatureAlgorithmName()
@@ -235,6 +242,8 @@ internal class Authenticator(
                 withContext(databaseDispatcher) {
                     db.increaseSignatureCounter(credId)
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 throw WebAuthnException.CredSrcStorageException(
                     "Failed to increase signature counter for credId: $credId",
@@ -246,6 +255,8 @@ internal class Authenticator(
                 withContext(databaseDispatcher) {
                     db.getSignatureCounter(credId)
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 throw WebAuthnException.CredSrcStorageException(
                     "Failed to get signature counter for credId: $credId",
@@ -380,6 +391,8 @@ internal class Authenticator(
                 withContext(databaseDispatcher) {
                     db.load(credId = descriptor.id)
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 throw WebAuthnException.CredSrcStorageException(
                     "Failed to load credential source for credId: ${descriptor.id}",
@@ -416,6 +429,8 @@ internal class Authenticator(
                     withContext(databaseDispatcher) {
                         db.load(credId = credId)
                     }
+                } catch (e: CancellationException) {
+                    throw e
                 } catch (e: Exception) {
                     throw WebAuthnException.CredSrcStorageException(
                         "Failed to load credential source for credId: $credId",
@@ -433,6 +448,8 @@ internal class Authenticator(
                 withContext(databaseDispatcher) {
                     db.loadAll(authType.aaguid)
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 throw WebAuthnException.CredSrcStorageException("Failed to load all credential sources", e)
             }
@@ -515,6 +532,8 @@ internal class Authenticator(
                 withContext(databaseDispatcher) {
                     db.delete(credId = credId)
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 throw WebAuthnException.CredSrcStorageException("Failed to delete credential for credId: $credId", e)
             }
@@ -553,6 +572,8 @@ internal class Authenticator(
             withContext(databaseDispatcher) {
                 db.store(credentialSource)
             }
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             throw WebAuthnException.CredSrcStorageException(
                 "Failed to store new credential for credId: ${credentialSource.id}",

--- a/webauthn/src/main/java/com/linecorp/webauthn/authenticator/keygenerator/BiometricKeyGenerator.kt
+++ b/webauthn/src/main/java/com/linecorp/webauthn/authenticator/keygenerator/BiometricKeyGenerator.kt
@@ -26,6 +26,7 @@ import com.linecorp.webauthn.model.getKeyProperties
 import com.linecorp.webauthn.model.getSignaturePaddings
 import java.security.KeyPair
 import java.security.KeyPairGenerator
+import java.security.ProviderException
 
 class BiometricKeyGenerator : Fido2KeyGenerator() {
 
@@ -40,6 +41,11 @@ class BiometricKeyGenerator : Fido2KeyGenerator() {
             return try {
                 generateBiometricFido2Key(keyAlias, challenge, publicKeyAlgorithm, true, userAuthenticationRequired)
             } catch (e: StrongBoxUnavailableException) {
+                generateBiometricFido2Key(keyAlias, challenge, publicKeyAlgorithm, false, userAuthenticationRequired)
+            } catch (e: ProviderException) {
+                // Some vendor StrongBox KeyMint implementations reject unsupported parameter
+                // combinations with a plain ProviderException (e.g. KeyMint UNIMPLEMENTED, -100)
+                // instead of StrongBoxUnavailableException. Retry once on the TEE-backed path.
                 generateBiometricFido2Key(keyAlias, challenge, publicKeyAlgorithm, false, userAuthenticationRequired)
             }
         } else {

--- a/webauthn/src/main/java/com/linecorp/webauthn/authenticator/keygenerator/DeviceCredentialKeyGenerator.kt
+++ b/webauthn/src/main/java/com/linecorp/webauthn/authenticator/keygenerator/DeviceCredentialKeyGenerator.kt
@@ -27,6 +27,7 @@ import com.linecorp.webauthn.model.getKeyProperties
 import com.linecorp.webauthn.model.getSignaturePaddings
 import java.security.KeyPair
 import java.security.KeyPairGenerator
+import java.security.ProviderException
 
 class DeviceCredentialKeyGenerator : Fido2KeyGenerator() {
 
@@ -47,6 +48,17 @@ class DeviceCredentialKeyGenerator : Fido2KeyGenerator() {
                     userAuthenticationRequired
                 )
             } catch (e: StrongBoxUnavailableException) {
+                generateDeviceCredentialFido2Key(
+                    keyAlias,
+                    challenge,
+                    publicKeyAlgorithm,
+                    false,
+                    userAuthenticationRequired
+                )
+            } catch (e: ProviderException) {
+                // Some vendor StrongBox KeyMint implementations reject unsupported parameter
+                // combinations with a plain ProviderException (e.g. KeyMint UNIMPLEMENTED, -100)
+                // instead of StrongBoxUnavailableException. Retry once on the TEE-backed path.
                 generateDeviceCredentialFido2Key(
                     keyAlias,
                     challenge,

--- a/webauthn/src/main/java/com/linecorp/webauthn/exceptions/WebAuthnException.kt
+++ b/webauthn/src/main/java/com/linecorp/webauthn/exceptions/WebAuthnException.kt
@@ -16,6 +16,8 @@
 
 package com.linecorp.webauthn.exceptions
 
+import androidx.biometric.BiometricPrompt
+
 sealed class WebAuthnException(override val message: String?, override val cause: Throwable? = null) :
     Exception(message, cause) {
 
@@ -23,14 +25,42 @@ sealed class WebAuthnException(override val message: String?, override val cause
         class ConstraintException(
             message: String? = "A mutation operation in a transaction failed because a constraint was not satisfied.",
             cause: Throwable? = null
-        ) : CoreException(message, cause)
+        ) : CoreException(message, cause) {
+            /**
+             * The raw status code from BiometricManager.canAuthenticate() explaining why
+             * authentication is unavailable (e.g. BIOMETRIC_ERROR_NONE_ENROLLED = 11,
+             * BIOMETRIC_ERROR_NO_HARDWARE = 12, BIOMETRIC_ERROR_SECURITY_UPDATE_REQUIRED = 15),
+             * or null when the reason is unknown.
+             */
+            var capabilityStatus: Int? = null
+                internal set
+        }
         class InvalidStateException(message: String? = "The object is in an invalid state.", cause: Throwable? = null) :
             CoreException(message, cause)
         class NotAllowedException(
             message: String? = "The request is not allowed by the user agent or the platform in the current context, " +
                 "possibly because the user denied permission.",
             cause: Throwable? = null
-        ) : CoreException(message, cause)
+        ) : CoreException(message, cause) {
+            /**
+             * The androidx.biometric BiometricPrompt error code that caused this failure
+             * (e.g. ERROR_USER_CANCELED = 10, ERROR_LOCKOUT = 7), or null when unavailable.
+             * Use this instead of matching the localized error message.
+             */
+            var errorCode: Int? = null
+                internal set
+
+            /**
+             * True when this failure is a user or system cancellation of the authentication
+             * prompt (ERROR_CANCELED, ERROR_USER_CANCELED, ERROR_NEGATIVE_BUTTON) rather than
+             * a genuine error. Cancellations are expected user behavior and should not be
+             * reported as errors in telemetry.
+             */
+            val isUserCancellation: Boolean
+                get() = errorCode == BiometricPrompt.ERROR_CANCELED ||
+                    errorCode == BiometricPrompt.ERROR_USER_CANCELED ||
+                    errorCode == BiometricPrompt.ERROR_NEGATIVE_BUTTON
+        }
         class NotSupportedException(message: String? = "The operation is not supported.", cause: Throwable? = null) :
             CoreException(message, cause)
         class TypeException(message: String? = null, cause: Throwable? = null) : CoreException(message, cause)

--- a/webauthn/src/main/java/com/linecorp/webauthn/exceptions/WebAuthnException.kt
+++ b/webauthn/src/main/java/com/linecorp/webauthn/exceptions/WebAuthnException.kt
@@ -43,9 +43,26 @@ sealed class WebAuthnException(override val message: String?, override val cause
             cause: Throwable? = null
         ) : CoreException(message, cause) {
             /**
-             * The androidx.biometric BiometricPrompt error code that caused this failure
-             * (e.g. ERROR_USER_CANCELED = 10, ERROR_LOCKOUT = 7), or null when unavailable.
-             * Use this instead of matching the localized error message.
+             * The androidx.biometric BiometricPrompt error code delivered by
+             * AuthenticationCallback.onAuthenticationError(errorCode, errString),
+             * or null when unavailable. Use this instead of matching the localized
+             * error message (errString), which varies by locale and vendor.
+             *
+             * Constants (androidx.biometric.BiometricPrompt, verified against 1.1.0):
+             * -  1 ERROR_HW_UNAVAILABLE          hardware temporarily unavailable (retry later)
+             * -  2 ERROR_UNABLE_TO_PROCESS       sensor could not process the input (retryable)
+             * -  3 ERROR_TIMEOUT                 prompt timed out with no input
+             * -  4 ERROR_NO_SPACE                not enough device storage
+             * -  5 ERROR_CANCELED                canceled by the system/app (e.g. backgrounded)
+             * -  7 ERROR_LOCKOUT                 too many attempts, temporary lockout
+             * -  8 ERROR_VENDOR                  vendor-specific error
+             * -  9 ERROR_LOCKOUT_PERMANENT       locked out until device credential unlock
+             * - 10 ERROR_USER_CANCELED           user dismissed the prompt
+             * - 11 ERROR_NO_BIOMETRICS           no biometrics enrolled
+             * - 12 ERROR_HW_NOT_PRESENT          no biometric hardware
+             * - 13 ERROR_NEGATIVE_BUTTON         user tapped the negative (cancel) button
+             * - 14 ERROR_NO_DEVICE_CREDENTIAL    no PIN/pattern/password configured
+             * - 15 ERROR_SECURITY_UPDATE_REQUIRED sensor disabled pending a security update
              */
             var errorCode: Int? = null
                 internal set

--- a/webauthn/src/main/java/com/linecorp/webauthn/exceptions/WebAuthnException.kt
+++ b/webauthn/src/main/java/com/linecorp/webauthn/exceptions/WebAuthnException.kt
@@ -16,6 +16,7 @@
 
 package com.linecorp.webauthn.exceptions
 
+import androidx.biometric.BiometricManager
 import androidx.biometric.BiometricPrompt
 
 sealed class WebAuthnException(override val message: String?, override val cause: Throwable? = null) :
@@ -34,6 +35,14 @@ sealed class WebAuthnException(override val message: String?, override val cause
              */
             var capabilityStatus: Int? = null
                 internal set
+
+            /**
+             * Human-readable constant name for [capabilityStatus]
+             * (e.g. 11 -> "BIOMETRIC_ERROR_NONE_ENROLLED"), or null when unavailable.
+             * Intended for logs and telemetry.
+             */
+            val capabilityStatusName: String?
+                get() = capabilityStatus?.let { biometricManagerStatusName(it) }
         }
         class InvalidStateException(message: String? = "The object is in an invalid state.", cause: Throwable? = null) :
             CoreException(message, cause)
@@ -66,6 +75,14 @@ sealed class WebAuthnException(override val message: String?, override val cause
              */
             var errorCode: Int? = null
                 internal set
+
+            /**
+             * Human-readable constant name for [errorCode]
+             * (e.g. 10 -> "ERROR_USER_CANCELED"), or null when unavailable.
+             * Intended for logs and telemetry.
+             */
+            val errorCodeName: String?
+                get() = errorCode?.let { biometricPromptErrorName(it) }
 
             /**
              * True when this failure is a user or system cancellation of the authentication
@@ -112,4 +129,43 @@ sealed class WebAuthnException(override val message: String?, override val cause
      */
     class DeletionException(message: String, cause: Throwable? = null, val trigger: Throwable? = null) :
         WebAuthnException(message, cause)
+}
+
+/**
+ * Maps an androidx.biometric.BiometricPrompt ERROR_* code to its constant name
+ * (verified against biometric 1.1.0). Used for logs so services can act on the
+ * failure without a lookup table.
+ */
+internal fun biometricPromptErrorName(code: Int): String = when (code) {
+    BiometricPrompt.ERROR_HW_UNAVAILABLE -> "ERROR_HW_UNAVAILABLE"
+    BiometricPrompt.ERROR_UNABLE_TO_PROCESS -> "ERROR_UNABLE_TO_PROCESS"
+    BiometricPrompt.ERROR_TIMEOUT -> "ERROR_TIMEOUT"
+    BiometricPrompt.ERROR_NO_SPACE -> "ERROR_NO_SPACE"
+    BiometricPrompt.ERROR_CANCELED -> "ERROR_CANCELED"
+    BiometricPrompt.ERROR_LOCKOUT -> "ERROR_LOCKOUT"
+    BiometricPrompt.ERROR_VENDOR -> "ERROR_VENDOR"
+    BiometricPrompt.ERROR_LOCKOUT_PERMANENT -> "ERROR_LOCKOUT_PERMANENT"
+    BiometricPrompt.ERROR_USER_CANCELED -> "ERROR_USER_CANCELED"
+    BiometricPrompt.ERROR_NO_BIOMETRICS -> "ERROR_NO_BIOMETRICS"
+    BiometricPrompt.ERROR_HW_NOT_PRESENT -> "ERROR_HW_NOT_PRESENT"
+    BiometricPrompt.ERROR_NEGATIVE_BUTTON -> "ERROR_NEGATIVE_BUTTON"
+    BiometricPrompt.ERROR_NO_DEVICE_CREDENTIAL -> "ERROR_NO_DEVICE_CREDENTIAL"
+    BiometricPrompt.ERROR_SECURITY_UPDATE_REQUIRED -> "ERROR_SECURITY_UPDATE_REQUIRED"
+    else -> "UNKNOWN_ERROR"
+}
+
+/**
+ * Maps an androidx.biometric.BiometricManager.canAuthenticate() status code to its
+ * constant name (verified against biometric 1.1.0). Note this is a different constant
+ * set from BiometricPrompt ERROR_* codes.
+ */
+internal fun biometricManagerStatusName(code: Int): String = when (code) {
+    BiometricManager.BIOMETRIC_SUCCESS -> "BIOMETRIC_SUCCESS"
+    BiometricManager.BIOMETRIC_STATUS_UNKNOWN -> "BIOMETRIC_STATUS_UNKNOWN"
+    BiometricManager.BIOMETRIC_ERROR_UNSUPPORTED -> "BIOMETRIC_ERROR_UNSUPPORTED"
+    BiometricManager.BIOMETRIC_ERROR_HW_UNAVAILABLE -> "BIOMETRIC_ERROR_HW_UNAVAILABLE"
+    BiometricManager.BIOMETRIC_ERROR_NONE_ENROLLED -> "BIOMETRIC_ERROR_NONE_ENROLLED"
+    BiometricManager.BIOMETRIC_ERROR_NO_HARDWARE -> "BIOMETRIC_ERROR_NO_HARDWARE"
+    BiometricManager.BIOMETRIC_ERROR_SECURITY_UPDATE_REQUIRED -> "BIOMETRIC_ERROR_SECURITY_UPDATE_REQUIRED"
+    else -> "UNKNOWN_STATUS"
 }

--- a/webauthn/src/main/java/com/linecorp/webauthn/exceptions/WebAuthnException.kt
+++ b/webauthn/src/main/java/com/linecorp/webauthn/exceptions/WebAuthnException.kt
@@ -90,8 +90,9 @@ sealed class WebAuthnException(override val message: String?, override val cause
      *
      * @param message The error message.
      * @param cause The cause of the issue during the deletion process.
-     * @param trigger The exception that triggered the deletion.
+     * @param trigger The exception that triggered the deletion - the original failure
+     * that the caller most likely wants to diagnose.
      */
-    class DeletionException(message: String, cause: Throwable? = null, trigger: Throwable? = null) :
+    class DeletionException(message: String, cause: Throwable? = null, val trigger: Throwable? = null) :
         WebAuthnException(message, cause)
 }

--- a/webauthn/src/main/java/com/linecorp/webauthn/exceptions/WebAuthnException.kt
+++ b/webauthn/src/main/java/com/linecorp/webauthn/exceptions/WebAuthnException.kt
@@ -128,7 +128,14 @@ sealed class WebAuthnException(override val message: String?, override val cause
      * that the caller most likely wants to diagnose.
      */
     class DeletionException(message: String, cause: Throwable? = null, val trigger: Throwable? = null) :
-        WebAuthnException(message, cause)
+        WebAuthnException(message, cause) {
+        init {
+            // Attach the trigger as a suppressed exception so plain stack-trace logging
+            // automatically prints the original failure ("Suppressed: ...") alongside
+            // the deletion failure, without requiring callers to read the property.
+            trigger?.let { addSuppressed(it) }
+        }
+    }
 }
 
 /**

--- a/webauthn/src/main/java/com/linecorp/webauthn/handler/BiometricAuthenticationHandler.kt
+++ b/webauthn/src/main/java/com/linecorp/webauthn/handler/BiometricAuthenticationHandler.kt
@@ -73,6 +73,10 @@ internal class BiometricAuthenticationHandler(
                             ?: "Input your Fingerprint or FaceID to ensure it's you!",
                     )
                     .setNegativeButtonText(fido2PromptInfo?.negativeButtonText ?: "Cancel")
+                    // Without this, the prompt defaults to allowing Class 2 (WEAK)
+                    // biometrics on the no-CryptoObject path, even though this handler
+                    // gates support on BIOMETRIC_STRONG and the assertion claims UV.
+                    .setAllowedAuthenticators(BiometricManager.Authenticators.BIOMETRIC_STRONG)
                     .build()
 
             val biometricPrompt =

--- a/webauthn/src/main/java/com/linecorp/webauthn/handler/BiometricAuthenticationHandler.kt
+++ b/webauthn/src/main/java/com/linecorp/webauthn/handler/BiometricAuthenticationHandler.kt
@@ -21,6 +21,7 @@ import androidx.biometric.BiometricManager
 import androidx.biometric.BiometricPrompt
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.FragmentActivity
+import androidx.lifecycle.Lifecycle
 import com.linecorp.webauthn.model.Fido2PromptInfo
 import com.linecorp.webauthn.model.Fido2UserAuthResult
 import java.security.Signature
@@ -51,6 +52,13 @@ internal class BiometricAuthenticationHandler(
         fido2PromptInfo: Fido2PromptInfo?,
         signatureProvider: (() -> Signature)?
     ): Fido2UserAuthResult = withContext(authHandlerDispatcher) {
+        if (!activity.lifecycle.currentState.isAtLeast(Lifecycle.State.RESUMED)) {
+            throw AuthenticationHandler.AuthenticationErrorException(
+                message = "BiometricPrompt requires Activity to be in RESUMED state. " +
+                    "Current state: ${activity.lifecycle.currentState}"
+            )
+        }
+
         suspendCancellableCoroutine { continuation ->
             val promptInfo =
                 BiometricPrompt.PromptInfo.Builder()
@@ -66,7 +74,7 @@ internal class BiometricAuthenticationHandler(
             val biometricPrompt =
                 BiometricPrompt(
                     activity,
-                    ContextCompat.getMainExecutor(activity.applicationContext),
+                    ContextCompat.getMainExecutor(activity),
                     object : BiometricPrompt.AuthenticationCallback() {
                         override fun onAuthenticationSucceeded(result: BiometricPrompt.AuthenticationResult) {
                             if (continuation.isActive) {
@@ -98,7 +106,13 @@ internal class BiometricAuthenticationHandler(
                 )
 
             continuation.invokeOnCancellation {
-                biometricPrompt.cancelAuthentication()
+                // invokeOnCancellation may be invoked from any thread, while
+                // cancelAuthentication() performs fragment operations that must run on
+                // the main thread. Post it to the main executor to avoid a crash when
+                // the calling scope is cancelled from a background thread.
+                ContextCompat.getMainExecutor(activity).execute {
+                    biometricPrompt.cancelAuthentication()
+                }
             }
 
             if (signatureProvider != null) {

--- a/webauthn/src/main/java/com/linecorp/webauthn/handler/BiometricAuthenticationHandler.kt
+++ b/webauthn/src/main/java/com/linecorp/webauthn/handler/BiometricAuthenticationHandler.kt
@@ -34,12 +34,16 @@ import kotlinx.coroutines.withContext
 internal class BiometricAuthenticationHandler(
     private val authHandlerDispatcher: CoroutineDispatcher = Dispatchers.Main,
 ) : AuthenticationHandler {
-    override fun isSupported(context: Context): Boolean {
-        val biometricManager = BiometricManager.from(context)
-        return biometricManager.canAuthenticate(
-            BiometricManager.Authenticators.BIOMETRIC_STRONG
-        ) == BiometricManager.BIOMETRIC_SUCCESS
-    }
+    /**
+     * Returns the raw BiometricManager.canAuthenticate() status code for the
+     * BIOMETRIC_STRONG authenticator class required by this handler.
+     */
+    internal fun capabilityStatus(context: Context): Int = BiometricManager.from(context).canAuthenticate(
+        BiometricManager.Authenticators.BIOMETRIC_STRONG
+    )
+
+    override fun isSupported(context: Context): Boolean =
+        capabilityStatus(context) == BiometricManager.BIOMETRIC_SUCCESS
 
     override suspend fun authenticate(
         activity: FragmentActivity,

--- a/webauthn/src/main/java/com/linecorp/webauthn/handler/BiometricAuthenticationHandler.kt
+++ b/webauthn/src/main/java/com/linecorp/webauthn/handler/BiometricAuthenticationHandler.kt
@@ -82,13 +82,22 @@ internal class BiometricAuthenticationHandler(
                     object : BiometricPrompt.AuthenticationCallback() {
                         override fun onAuthenticationSucceeded(result: BiometricPrompt.AuthenticationResult) {
                             if (continuation.isActive) {
-                                continuation.resumeWith(
-                                    Result.success(
-                                        Fido2UserAuthResult(
-                                            signature = result.cryptoObject?.signature
+                                val signature = result.cryptoObject?.signature
+                                if (signatureProvider != null && signature == null) {
+                                    // A CryptoObject was requested but none came back:
+                                    // fail loudly here instead of crashing later on a
+                                    // null signature during assertion generation.
+                                    continuation.resumeWithException(
+                                        AuthenticationHandler.AuthenticationErrorException(
+                                            message = "Authentication succeeded but no signature " +
+                                                "was returned from the CryptoObject."
                                         )
                                     )
-                                )
+                                } else {
+                                    continuation.resumeWith(
+                                        Result.success(Fido2UserAuthResult(signature = signature))
+                                    )
+                                }
                             }
                         }
 

--- a/webauthn/src/main/java/com/linecorp/webauthn/handler/DeviceCredentialAuthenticationHandler.kt
+++ b/webauthn/src/main/java/com/linecorp/webauthn/handler/DeviceCredentialAuthenticationHandler.kt
@@ -22,6 +22,7 @@ import androidx.biometric.BiometricManager
 import androidx.biometric.BiometricPrompt
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.FragmentActivity
+import androidx.lifecycle.Lifecycle
 import com.linecorp.webauthn.model.Fido2PromptInfo
 import com.linecorp.webauthn.model.Fido2UserAuthResult
 import java.security.Signature
@@ -64,6 +65,13 @@ internal class DeviceCredentialAuthenticationHandler(
         fido2PromptInfo: Fido2PromptInfo?,
         signatureProvider: (() -> Signature)?
     ): Fido2UserAuthResult = withContext(authHandlerDispatcher) {
+        if (!activity.lifecycle.currentState.isAtLeast(Lifecycle.State.RESUMED)) {
+            throw AuthenticationHandler.AuthenticationErrorException(
+                message = "BiometricPrompt requires Activity to be in RESUMED state. " +
+                    "Current state: ${activity.lifecycle.currentState}"
+            )
+        }
+
         suspendCancellableCoroutine { continuation ->
             val promptInfo =
                 BiometricPrompt.PromptInfo.Builder()
@@ -82,16 +90,18 @@ internal class DeviceCredentialAuthenticationHandler(
             val biometricPrompt =
                 BiometricPrompt(
                     activity,
-                    ContextCompat.getMainExecutor(activity.applicationContext),
+                    ContextCompat.getMainExecutor(activity),
                     object : BiometricPrompt.AuthenticationCallback() {
                         override fun onAuthenticationSucceeded(result: BiometricPrompt.AuthenticationResult) {
-                            continuation.resumeWith(
-                                Result.success(
-                                    Fido2UserAuthResult(
-                                        signature = result.cryptoObject?.signature
+                            if (continuation.isActive) {
+                                continuation.resumeWith(
+                                    Result.success(
+                                        Fido2UserAuthResult(
+                                            signature = result.cryptoObject?.signature
+                                        )
                                     )
                                 )
-                            )
+                            }
                         }
 
                         override fun onAuthenticationFailed() {
@@ -99,18 +109,26 @@ internal class DeviceCredentialAuthenticationHandler(
                         }
 
                         override fun onAuthenticationError(errorCode: Int, errString: CharSequence) {
-                            continuation.resumeWithException(
-                                AuthenticationHandler.AuthenticationErrorException(
-                                    errorCode,
-                                    "Biometric authentication error: $errString"
+                            if (continuation.isActive) {
+                                continuation.resumeWithException(
+                                    AuthenticationHandler.AuthenticationErrorException(
+                                        errorCode,
+                                        "Biometric authentication error: $errString"
+                                    )
                                 )
-                            )
+                            }
                         }
                     },
                 )
 
             continuation.invokeOnCancellation {
-                biometricPrompt.cancelAuthentication()
+                // invokeOnCancellation may be invoked from any thread, while
+                // cancelAuthentication() performs fragment operations that must run on
+                // the main thread. Post it to the main executor to avoid a crash when
+                // the calling scope is cancelled from a background thread.
+                ContextCompat.getMainExecutor(activity).execute {
+                    biometricPrompt.cancelAuthentication()
+                }
             }
 
             if (signatureProvider != null) {

--- a/webauthn/src/main/java/com/linecorp/webauthn/handler/DeviceCredentialAuthenticationHandler.kt
+++ b/webauthn/src/main/java/com/linecorp/webauthn/handler/DeviceCredentialAuthenticationHandler.kt
@@ -38,17 +38,28 @@ internal class DeviceCredentialAuthenticationHandler(
 
     private val keyguardManagerWrapper = KeyguardManagerWrapper()
 
-    override fun isSupported(context: Context): Boolean = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+    /**
+     * Returns the raw BiometricManager.canAuthenticate() status code for the authenticator
+     * classes required by this handler. On API < 30 the KeyguardManager check is mapped to
+     * BIOMETRIC_SUCCESS / BIOMETRIC_ERROR_NONE_ENROLLED (no secure lock screen configured).
+     */
+    internal fun capabilityStatus(context: Context): Int = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
         // API level >= 30
-        val biometricManager = BiometricManager.from(context)
-        biometricManager.canAuthenticate(
+        BiometricManager.from(context).canAuthenticate(
             BiometricManager.Authenticators.BIOMETRIC_STRONG or
                 BiometricManager.Authenticators.DEVICE_CREDENTIAL
-        ) == BiometricManager.BIOMETRIC_SUCCESS
+        )
     } else {
         // API level < 30
-        keyguardManagerWrapper.isSupported(context)
+        if (keyguardManagerWrapper.isSupported(context)) {
+            BiometricManager.BIOMETRIC_SUCCESS
+        } else {
+            BiometricManager.BIOMETRIC_ERROR_NONE_ENROLLED
+        }
     }
+
+    override fun isSupported(context: Context): Boolean =
+        capabilityStatus(context) == BiometricManager.BIOMETRIC_SUCCESS
 
     override suspend fun authenticate(
         activity: FragmentActivity,

--- a/webauthn/src/main/java/com/linecorp/webauthn/handler/DeviceCredentialAuthenticationHandler.kt
+++ b/webauthn/src/main/java/com/linecorp/webauthn/handler/DeviceCredentialAuthenticationHandler.kt
@@ -105,13 +105,22 @@ internal class DeviceCredentialAuthenticationHandler(
                     object : BiometricPrompt.AuthenticationCallback() {
                         override fun onAuthenticationSucceeded(result: BiometricPrompt.AuthenticationResult) {
                             if (continuation.isActive) {
-                                continuation.resumeWith(
-                                    Result.success(
-                                        Fido2UserAuthResult(
-                                            signature = result.cryptoObject?.signature
+                                val signature = result.cryptoObject?.signature
+                                if (signatureProvider != null && signature == null) {
+                                    // A CryptoObject was requested but none came back:
+                                    // fail loudly here instead of crashing later on a
+                                    // null signature during assertion generation.
+                                    continuation.resumeWithException(
+                                        AuthenticationHandler.AuthenticationErrorException(
+                                            message = "Authentication succeeded but no signature " +
+                                                "was returned from the CryptoObject."
                                         )
                                     )
-                                )
+                                } else {
+                                    continuation.resumeWith(
+                                        Result.success(Fido2UserAuthResult(signature = signature))
+                                    )
+                                }
                             }
                         }
 
@@ -156,6 +165,16 @@ internal class DeviceCredentialAuthenticationHandler(
         fido2PromptInfo: Fido2PromptInfo?,
         signatureProvider: (() -> Signature)?
     ): Fido2UserAuthResult = withContext(authHandlerDispatcher) {
+        if (!activity.lifecycle.currentState.isAtLeast(Lifecycle.State.RESUMED)) {
+            // Mirrors the BiometricPrompt path: launching the confirm-device-credential
+            // activity from the background either fails silently (suspending the caller
+            // forever) or is blocked by background-activity-start restrictions.
+            throw AuthenticationHandler.AuthenticationErrorException(
+                message = "KeyguardManager authentication requires Activity to be in RESUMED state. " +
+                    "Current state: ${activity.lifecycle.currentState}"
+            )
+        }
+
         try {
             keyguardManagerWrapper.authenticate(activity, fido2PromptInfo)
             val signature = signatureProvider?.invoke()

--- a/webauthn/src/main/java/com/linecorp/webauthn/handler/DeviceCredentialAuthenticationHandler.kt
+++ b/webauthn/src/main/java/com/linecorp/webauthn/handler/DeviceCredentialAuthenticationHandler.kt
@@ -27,6 +27,7 @@ import com.linecorp.webauthn.model.Fido2PromptInfo
 import com.linecorp.webauthn.model.Fido2UserAuthResult
 import java.security.Signature
 import kotlin.coroutines.resumeWithException
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.suspendCancellableCoroutine
@@ -195,6 +196,10 @@ internal class DeviceCredentialAuthenticationHandler(
                 message = e.message,
                 cause = e
             )
+        } catch (e: CancellationException) {
+            // Let coroutine cancellation propagate instead of reporting it as a
+            // (user-denied) authentication error.
+            throw e
         } catch (e: Exception) {
             throw AuthenticationHandler.AuthenticationErrorException(
                 message = "An unexpected error occurred",

--- a/webauthn/src/main/java/com/linecorp/webauthn/handler/KeyguardManagerWrapper.kt
+++ b/webauthn/src/main/java/com/linecorp/webauthn/handler/KeyguardManagerWrapper.kt
@@ -54,6 +54,12 @@ class KeyguardManagerWrapper {
         Log.d("KeyguardManagerWrapper", "Starting AuthenticationActivity with intent")
 
         return suspendCancellableCoroutine { continuation ->
+            continuation.invokeOnCancellation {
+                // The calling scope was cancelled: drop the pending callback so a late
+                // activity result cannot resume a stale (or a subsequent flow's)
+                // continuation, and dismiss the confirm-credential UI if it is still shown.
+                AuthenticationActivity.cancel()
+            }
             AuthenticationActivity.start(context, intent) { result, errorCode ->
                 if (result) {
                     Log.d("KeyguardManagerWrapper", "Authentication succeeded")
@@ -77,6 +83,10 @@ class KeyguardManagerWrapper {
             private const val REQUEST_CODE_CONFIRM_DEVICE_CREDENTIAL = 1
             private var callback: ((Boolean, Int?) -> Unit)? = null
 
+            // The currently displayed activity, so a cancelled coroutine can dismiss it.
+            // Cleared in onDestroy to bound the reference to the visible lifetime.
+            private var liveActivity: AuthenticationActivity? = null
+
             fun start(context: Context, intent: Intent, callback: (Boolean, Int?) -> Unit) {
                 this.callback = callback
                 val activityIntent = Intent(context, AuthenticationActivity::class.java).apply {
@@ -96,10 +106,22 @@ class KeyguardManagerWrapper {
                 callback?.invoke(result, errorCode)
                 callback = null
             }
+
+            /**
+             * Invoked when the calling coroutine is cancelled. Drops the pending callback
+             * (so a late activity result is ignored rather than resuming a stale/other
+             * continuation) and finishes the confirm-credential activity if it is still
+             * on screen. finish() must run on the main thread.
+             */
+            fun cancel() {
+                callback = null
+                liveActivity?.let { activity -> activity.runOnUiThread { activity.finish() } }
+            }
         }
 
         override fun onCreate(savedInstanceState: Bundle?) {
             super.onCreate(savedInstanceState)
+            liveActivity = this
             if (savedInstanceState != null) {
                 // Re-created (configuration change / process restore): the confirmation
                 // launched from the original instance is still in flight; do not fire a
@@ -137,6 +159,13 @@ class KeyguardManagerWrapper {
                 }
             }
             finish()
+        }
+
+        override fun onDestroy() {
+            super.onDestroy()
+            if (liveActivity === this) {
+                liveActivity = null
+            }
         }
     }
 }

--- a/webauthn/src/main/java/com/linecorp/webauthn/handler/KeyguardManagerWrapper.kt
+++ b/webauthn/src/main/java/com/linecorp/webauthn/handler/KeyguardManagerWrapper.kt
@@ -86,17 +86,33 @@ class KeyguardManagerWrapper {
                 Log.d("AuthenticationActivity", "Starting activity with intent")
                 context.startActivity(activityIntent)
             }
+
+            /**
+             * Delivers the result exactly once and releases the callback reference so a
+             * re-created activity cannot deliver a second result (which would crash the
+             * already-resumed continuation) and the captured continuation is not leaked.
+             */
+            private fun deliverResult(result: Boolean, errorCode: Int?) {
+                callback?.invoke(result, errorCode)
+                callback = null
+            }
         }
 
         override fun onCreate(savedInstanceState: Bundle?) {
             super.onCreate(savedInstanceState)
+            if (savedInstanceState != null) {
+                // Re-created (configuration change / process restore): the confirmation
+                // launched from the original instance is still in flight; do not fire a
+                // second one.
+                return
+            }
             val intent = intent.getParcelableExtra<Intent>("fido2_auth_intent")
             if (intent != null) {
                 Log.d("AuthenticationActivity", "Starting activity for result")
                 startActivityForResult(intent, REQUEST_CODE_CONFIRM_DEVICE_CREDENTIAL)
             } else {
                 Log.d("AuthenticationActivity", "Intent is null, finishing activity")
-                callback?.invoke(false, BiometricPrompt.BIOMETRIC_ERROR_UNABLE_TO_PROCESS)
+                deliverResult(false, BiometricPrompt.BIOMETRIC_ERROR_UNABLE_TO_PROCESS)
                 finish()
             }
         }
@@ -107,16 +123,16 @@ class KeyguardManagerWrapper {
                 Log.d("AuthenticationActivity", "Received result: $resultCode")
                 when (resultCode) {
                     RESULT_OK -> {
-                        callback?.invoke(true, null)
+                        deliverResult(true, null)
                         Log.d("AuthenticationActivity", "Authentication succeeded")
                     }
                     RESULT_CANCELED -> {
                         Log.d("AuthenticationActivity", "Authentication canceled")
-                        callback?.invoke(false, BiometricPrompt.BIOMETRIC_ERROR_USER_CANCELED)
+                        deliverResult(false, BiometricPrompt.BIOMETRIC_ERROR_USER_CANCELED)
                     }
                     else -> {
                         Log.d("AuthenticationActivity", "Authentication failed")
-                        callback?.invoke(false, BiometricPrompt.BIOMETRIC_ERROR_UNABLE_TO_PROCESS)
+                        deliverResult(false, BiometricPrompt.BIOMETRIC_ERROR_UNABLE_TO_PROCESS)
                     }
                 }
             }

--- a/webauthn/src/main/java/com/linecorp/webauthn/model/AttestationObject.kt
+++ b/webauthn/src/main/java/com/linecorp/webauthn/model/AttestationObject.kt
@@ -38,7 +38,8 @@ data class AttestationObject(val authData: ByteArray, val fmt: String, val attSt
         if (fmt == AttestationStatementFormat.NONE.value) {
             builder.putMap("attStmt")
         } else {
-            attStmt.toCBOR(builder.startMap("attStmt"))
+            // putMap() keeps the nested attStmt map definite-length (CTAP2 canonical form).
+            attStmt.toCBOR(builder.putMap("attStmt"))
         }
         return builder.end()
     }

--- a/webauthn/src/main/java/com/linecorp/webauthn/model/AttestationStatement.kt
+++ b/webauthn/src/main/java/com/linecorp/webauthn/model/AttestationStatement.kt
@@ -61,7 +61,7 @@ enum class COSEAlgorithmIdentifier(val value: Long) {
     ES256(-7), // ECDSA with SHA-256
     ES384(-35), // ECDSA with SHA-384
     ES512(-36), // ECDSA with SHA-512
-    ES256K(-43), // ECDSA using P-256K and SHA-256
+    ES256K(-47), // ECDSA using secp256k1 curve and SHA-256
     ;
 
     companion object {

--- a/webauthn/src/main/java/com/linecorp/webauthn/model/AttestationStatement.kt
+++ b/webauthn/src/main/java/com/linecorp/webauthn/model/AttestationStatement.kt
@@ -115,7 +115,8 @@ fun COSEAlgorithmIdentifier.getAlgorithmParameterSpec(): AlgorithmParameterSpec?
     COSEAlgorithmIdentifier.EdDSA -> null
     COSEAlgorithmIdentifier.ES256 -> ECGenParameterSpec("secp256r1")
     COSEAlgorithmIdentifier.ES384 -> ECGenParameterSpec("secp384r1")
-    COSEAlgorithmIdentifier.ES512 -> ECGenParameterSpec("secp512r1")
+    // ES512 uses the P-521 curve; "secp521r1" is the correct JCA name (not secp512r1).
+    COSEAlgorithmIdentifier.ES512 -> ECGenParameterSpec("secp521r1")
     COSEAlgorithmIdentifier.ES256K -> ECGenParameterSpec("secp256k1")
 }
 

--- a/webauthn/src/main/java/com/linecorp/webauthn/model/AuthenticatorData.kt
+++ b/webauthn/src/main/java/com/linecorp/webauthn/model/AuthenticatorData.kt
@@ -19,6 +19,7 @@ package com.linecorp.webauthn.model
 import co.nstant.`in`.cbor.builder.AbstractBuilder
 import co.nstant.`in`.cbor.builder.MapBuilder
 import com.linecorp.webauthn.exceptions.WebAuthnException
+import java.math.BigInteger
 import java.nio.ByteBuffer
 import java.security.interfaces.ECPublicKey
 
@@ -101,8 +102,8 @@ class EC2COSEKey(var kty: Int, var alg: Int, var crv: Int, var x: ByteArray, var
         kty = 2,
         alg = -7,
         crv = 1,
-        x = ecPublicKey.w.affineX.toByteArray(),
-        y = ecPublicKey.w.affineY.toByteArray(),
+        x = ecPublicKey.w.affineX.toFixedLengthByteArray(ecPublicKey.fieldSizeBytes()),
+        y = ecPublicKey.w.affineY.toFixedLengthByteArray(ecPublicKey.fieldSizeBytes()),
     )
 
     override fun <T : AbstractBuilder<*>?> toCBOR(builder: MapBuilder<T>): T = builder
@@ -112,6 +113,25 @@ class EC2COSEKey(var kty: Int, var alg: Int, var crv: Int, var x: ByteArray, var
         .put(-2, x)
         .put(-3, y)
         .end()
+}
+
+private fun ECPublicKey.fieldSizeBytes(): Int = (params.curve.field.fieldSize + 7) / 8
+
+/**
+ * Converts this integer to the SEC1 fixed-length unsigned big-endian encoding required for
+ * COSE EC2 coordinates (RFC 8152 section 13.1.1: exactly the field size in octets, leading
+ * zero octets preserved). BigInteger.toByteArray() returns the minimal two's-complement
+ * form instead: it prepends a 0x00 sign octet when the top bit is set and drops leading
+ * zero octets, both of which produce a spec-invalid credentialPublicKey.
+ */
+private fun BigInteger.toFixedLengthByteArray(length: Int): ByteArray {
+    val raw = toByteArray()
+    return when {
+        raw.size == length -> raw
+        raw.size == length + 1 && raw[0] == 0.toByte() -> raw.copyOfRange(1, raw.size)
+        raw.size < length -> ByteArray(length - raw.size) + raw
+        else -> throw WebAuthnException.EncodingException("EC coordinate is larger than the curve field size.")
+    }
 }
 
 enum class AuthenticatorDataFlags(val value: UByte) {

--- a/webauthn/src/main/java/com/linecorp/webauthn/model/AuthenticatorSelectionCriteria.kt
+++ b/webauthn/src/main/java/com/linecorp/webauthn/model/AuthenticatorSelectionCriteria.kt
@@ -24,6 +24,7 @@ data class AuthenticatorSelectionCriteria(
 enum class UserVerificationRequirement(val value: String) {
     REQUIRED("required"),
     PREFERRED("preferred"),
+    DISCOURAGED("discouraged"),
     ;
 
     companion object {

--- a/webauthn/src/main/java/com/linecorp/webauthn/model/CborSerializable.kt
+++ b/webauthn/src/main/java/com/linecorp/webauthn/model/CborSerializable.kt
@@ -26,7 +26,7 @@ import java.io.ByteArrayOutputStream
 interface CborSerializable {
     fun <T : AbstractBuilder<*>?> toCBOR(builder: MapBuilder<T>): T
 
-    fun toCBOR(canonical: Boolean = true): ByteArray {
+    fun toCBOR(): ByteArray {
         try {
             val baos = ByteArrayOutputStream()
             // addMap() produces a definite-length map. startMap() would produce an

--- a/webauthn/src/main/java/com/linecorp/webauthn/model/CborSerializable.kt
+++ b/webauthn/src/main/java/com/linecorp/webauthn/model/CborSerializable.kt
@@ -29,7 +29,10 @@ interface CborSerializable {
     fun toCBOR(canonical: Boolean = true): ByteArray {
         try {
             val baos = ByteArrayOutputStream()
-            CborEncoder(baos).encode(toCBOR(CborBuilder().startMap()).build())
+            // addMap() produces a definite-length map. startMap() would produce an
+            // indefinite-length (chunked) map, which violates the CTAP2 canonical CBOR
+            // encoding form required for attestationObject and credentialPublicKey.
+            CborEncoder(baos).encode(toCBOR(CborBuilder().addMap()).build())
             return baos.toByteArray()
         } catch (e: Exception) {
             throw WebAuthnException.EncodingException("Cannot convert Attestation Object to CBOR.", e)

--- a/webauthn/src/main/java/com/linecorp/webauthn/publickeycredential/PublicKeyCredential.kt
+++ b/webauthn/src/main/java/com/linecorp/webauthn/publickeycredential/PublicKeyCredential.kt
@@ -46,6 +46,8 @@ import com.linecorp.webauthn.rp.RegistrationData
 import com.linecorp.webauthn.rp.RegistrationOptions
 import com.linecorp.webauthn.rp.RelyingParty
 import com.linecorp.webauthn.util.Fido2Util
+import com.linecorp.webauthn.util.SecureExecutionHelper
+import com.linecorp.webauthn.util.base64urlToByteArray
 import com.linecorp.webauthn.util.toBase64url
 import java.security.MessageDigest
 import kotlinx.coroutines.CancellationException
@@ -244,29 +246,23 @@ class PublicKeyCredential(
      * @throws WebAuthnException.CredSrcStorageException If there is an error loading credentials from the database.
      */
     suspend fun getAllAccounts(): List<com.linecorp.webauthn.model.PublicKeyCredentialSource> {
-        val result = mutableListOf<com.linecorp.webauthn.model.PublicKeyCredentialSource>()
-        for (authMethod in AuthenticationMethod.entries) {
-            for (fmt in AttestationStatementFormat.entries) {
-                val authenticator = authenticatorProvider.getAuthenticator(
-                    authenticationMethod = authMethod,
-                    attestationStatement = fmt,
-                    fido2PromptInfo = null,
-                )
-                val credentials: List<com.linecorp.webauthn.model.PublicKeyCredentialSource> = try {
-                    withContext(databaseDispatcher) {
-                        authenticator.db.loadAll()
-                    }
-                } catch (e: Exception) {
-                    throw WebAuthnException.CredSrcStorageException(
-                        "Failed to load credentials for authenticator type: ${authenticator.authType}",
-                        e
-                    )
-                }
-                result.addAll(credentials)
+        // loadAll() without an aaguid filter already returns every stored credential, so a
+        // single call is enough. Iterating authenticator types here would return each
+        // credential once per type (4x duplicates).
+        val authenticator = authenticatorProvider.getAuthenticator(
+            authenticationMethod = authenticationMethod,
+            attestationStatement = attestationStatement,
+            fido2PromptInfo = null,
+        )
+        return try {
+            withContext(databaseDispatcher) {
+                authenticator.db.loadAll()
             }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            throw WebAuthnException.CredSrcStorageException("Failed to load all credentials", e)
         }
-
-        return result
     }
 
     /**
@@ -275,24 +271,26 @@ class PublicKeyCredential(
      * @throws WebAuthnException.CredSrcStorageException If there is an error loading or deleting credentials from the database.
      */
     suspend fun deleteAllAccounts() {
-        for (authMethod in AuthenticationMethod.entries) {
-            for (fmt in AttestationStatementFormat.entries) {
-                val authenticator = authenticatorProvider.getAuthenticator(
-                    authenticationMethod = authMethod,
-                    attestationStatement = fmt,
-                    fido2PromptInfo = null,
-                )
+        val authenticator = authenticatorProvider.getAuthenticator(
+            authenticationMethod = authenticationMethod,
+            attestationStatement = attestationStatement,
+            fido2PromptInfo = null,
+        )
 
-                try {
-                    withContext(databaseDispatcher) {
-                        authenticator.db.loadAll().forEach { credential ->
-                            authenticator.db.delete(credential.id)
-                        }
-                    }
-                } catch (e: Exception) {
-                    throw WebAuthnException.CredSrcStorageException("Failed to load and delete all credentials", e)
+        try {
+            withContext(databaseDispatcher) {
+                authenticator.db.loadAll().forEach { credential ->
+                    // Delete the hardware-backed private key together with the DB row;
+                    // removing only the row would leave orphaned keys in the KeyStore.
+                    // The credential id is the KeyStore alias (see Authenticator).
+                    SecureExecutionHelper.deleteKey(credential.id)
+                    authenticator.db.delete(credential.id)
                 }
             }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            throw WebAuthnException.CredSrcStorageException("Failed to load and delete all credentials", e)
         }
     }
 
@@ -314,9 +312,22 @@ class PublicKeyCredential(
         fido2PromptInfo: Fido2PromptInfo? = null
     ): PublicKeyCredentialCreateResult {
         try {
-            if (options.user.id.length !in 1..64) {
+            // WebAuthn requires user.id to be 1..64 BYTES. The field carries the
+            // base64url encoding of those bytes (it is decoded as base64url at assertion
+            // time), so validate by decoding instead of counting string characters:
+            // a spec-valid 64-byte id encodes to ~86 characters and was wrongly rejected
+            // before, while a non-decodable id would only crash later during get().
+            val userIdBytes = try {
+                options.user.id.base64urlToByteArray()
+            } catch (e: WebAuthnException) {
                 throw WebAuthnException.CoreException.TypeException(
-                    "The length of the user id must be between 1 and 64."
+                    "user.id must be a base64url-encoded byte sequence.",
+                    e
+                )
+            }
+            if (userIdBytes.size !in 1..64) {
+                throw WebAuthnException.CoreException.TypeException(
+                    "The length of the user id must be between 1 and 64 bytes."
                 )
             }
 

--- a/webauthn/src/main/java/com/linecorp/webauthn/publickeycredential/PublicKeyCredential.kt
+++ b/webauthn/src/main/java/com/linecorp/webauthn/publickeycredential/PublicKeyCredential.kt
@@ -171,6 +171,8 @@ class PublicKeyCredential(
 
                 try {
                     authenticator.retryCleanup(createResult.id, maxTries = 2, delayMillis = 1000)
+                } catch (e2: CancellationException) {
+                    throw e2
                 } catch (e2: Throwable) {
                     throw WebAuthnException.DeletionException(
                         "Error occurred while deleting key: $e2",

--- a/webauthn/src/main/java/com/linecorp/webauthn/publickeycredential/PublicKeyCredential.kt
+++ b/webauthn/src/main/java/com/linecorp/webauthn/publickeycredential/PublicKeyCredential.kt
@@ -16,11 +16,14 @@
 
 package com.linecorp.webauthn.publickeycredential
 
+import android.content.Context
 import androidx.fragment.app.FragmentActivity
 import com.linecorp.webauthn.authenticator.Authenticator
 import com.linecorp.webauthn.authenticator.AuthenticatorProvider
 import com.linecorp.webauthn.db.CredentialSourceStorage
 import com.linecorp.webauthn.exceptions.WebAuthnException
+import com.linecorp.webauthn.handler.BiometricAuthenticationHandler
+import com.linecorp.webauthn.handler.DeviceCredentialAuthenticationHandler
 import com.linecorp.webauthn.model.AttestationStatementFormat
 import com.linecorp.webauthn.model.AuthenticationMethod
 import com.linecorp.webauthn.model.AuthenticatorAssertionResponse
@@ -79,6 +82,29 @@ class PublicKeyCredential(
     }
 
     internal lateinit var authenticator: Authenticator
+
+    /**
+     * Returns the raw androidx BiometricManager.canAuthenticate() status code for the
+     * authentication method this instance was configured with, without starting any UI.
+     *
+     * Call this BEFORE offering FIDO registration/authentication so unsupported devices can
+     * be routed to an alternative instead of failing mid-flow with a ConstraintException:
+     * - BiometricManager.BIOMETRIC_SUCCESS (0): authentication is available.
+     * - BIOMETRIC_ERROR_NONE_ENROLLED (11): no (strong) biometric or credential enrolled -
+     *   guide the user to enrollment.
+     * - BIOMETRIC_ERROR_NO_HARDWARE (12): the device has no capable hardware - hide the
+     *   FIDO entry point or fall back per policy.
+     * - BIOMETRIC_ERROR_SECURITY_UPDATE_REQUIRED (15): a security update is required first.
+     *
+     * @param context The application context.
+     * @return A BiometricManager status code.
+     */
+    fun canAuthenticate(context: Context): Int = when (authenticationMethod) {
+        AuthenticationMethod.Biometric ->
+            BiometricAuthenticationHandler(authenticationDispatcher).capabilityStatus(context)
+        AuthenticationMethod.DeviceCredential ->
+            DeviceCredentialAuthenticationHandler(authenticationDispatcher).capabilityStatus(context)
+    }
 
     /**
      * Initiates the registration process for a new credential.

--- a/webauthn/src/main/java/com/linecorp/webauthn/publickeycredential/PublicKeyCredential.kt
+++ b/webauthn/src/main/java/com/linecorp/webauthn/publickeycredential/PublicKeyCredential.kt
@@ -48,6 +48,7 @@ import com.linecorp.webauthn.rp.RelyingParty
 import com.linecorp.webauthn.util.Fido2Util
 import com.linecorp.webauthn.util.toBase64url
 import java.security.MessageDigest
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.sync.Mutex
@@ -127,6 +128,8 @@ class PublicKeyCredential(
                 withContext(relyingPartyDispatcher) {
                     rpClient.getRegistrationData(options)
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Throwable) {
                 throw WebAuthnException.RpException(
                     "Error occurred while getting registration data from rp: $e",
@@ -153,6 +156,11 @@ class PublicKeyCredential(
                 withContext(relyingPartyDispatcher) {
                     rpClient.verifyRegistration(createResult)
                 }
+            } catch (e: CancellationException) {
+                // Roll back the locally stored credential (cleanup itself is
+                // NonCancellable), then let cancellation propagate.
+                runCatching { authenticator.cleanup(createResult.id) }
+                throw e
             } catch (e: Throwable) {
                 val rpException = WebAuthnException.RpException(
                     "Error occurred while verifying registration data from rp: $e",
@@ -170,7 +178,7 @@ class PublicKeyCredential(
                 }
                 throw rpException
             }
-        }
+        }.onFailure { if (it is CancellationException) throw it }
     }
 
     /**
@@ -193,6 +201,8 @@ class PublicKeyCredential(
                 withContext(relyingPartyDispatcher) {
                     rpClient.getAuthenticationData(options)
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Throwable) {
                 throw WebAuthnException.RpException(
                     "Error occurred while getting authentication data from rp: $e",
@@ -216,13 +226,15 @@ class PublicKeyCredential(
                 withContext(relyingPartyDispatcher) {
                     rpClient.verifyAuthentication(getResult)
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Throwable) {
                 throw WebAuthnException.RpException(
                     "Error occurred while verifying authentication data from rp: $e",
                     e
                 )
             }
-        }
+        }.onFailure { if (it is CancellationException) throw it }
     }
 
     /**
@@ -345,6 +357,8 @@ class PublicKeyCredential(
                 ),
                 clientExtensionsOutput = options.extensions?.processClientExtensionsOutput(),
             )
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             if (e is WebAuthnException) {
                 throw e
@@ -374,40 +388,55 @@ class PublicKeyCredential(
         options: PublicKeyCredentialRequestOptions,
         fido2PromptInfo: Fido2PromptInfo? = null
     ): PublicKeyCredentialGetResult {
-        val collectedClientData = CollectedClientData(
-            type = "webauthn.get",
-            challenge = options.challenge,
-            origin = Fido2Util.getPackageFacetID(activity.applicationContext),
-        )
-        val clientDataJSON: ByteArray = Json.encodeToString(collectedClientData).toByteArray()
-        val clientDataHash: ByteArray =
-            MessageDigest.getInstance("SHA-256").digest(clientDataJSON)
+        try {
+            val collectedClientData = CollectedClientData(
+                type = "webauthn.get",
+                challenge = options.challenge,
+                origin = Fido2Util.getPackageFacetID(activity.applicationContext),
+            )
+            val clientDataJSON: ByteArray = Json.encodeToString(collectedClientData).toByteArray()
+            val clientDataHash: ByteArray =
+                MessageDigest.getInstance("SHA-256").digest(clientDataJSON)
 
-        authenticator = authenticatorProvider.getAuthenticator(
-            authenticationMethod = authenticationMethod,
-            attestationStatement = attestationStatement,
-            fido2PromptInfo = fido2PromptInfo
-        )
+            authenticator = authenticatorProvider.getAuthenticator(
+                authenticationMethod = authenticationMethod,
+                attestationStatement = attestationStatement,
+                fido2PromptInfo = fido2PromptInfo
+            )
 
-        val authGetAssertionResult: AuthenticatorGetAssertionResult = authenticator.getAssertion(
-            activity = activity,
-            rpId = options.rpId,
-            hash = clientDataHash,
-            allowCredDescriptorList = options.allowCredentials,
-            extensions = options.extensions?.processAuthenticatorExtensionsInput(),
-        ).getOrThrow()
+            val authGetAssertionResult: AuthenticatorGetAssertionResult = authenticator.getAssertion(
+                activity = activity,
+                rpId = options.rpId,
+                hash = clientDataHash,
+                allowCredDescriptorList = options.allowCredentials,
+                extensions = options.extensions?.processAuthenticatorExtensionsInput(),
+            ).getOrThrow()
 
-        return PublicKeyCredentialGetResult(
-            id = authGetAssertionResult.credentialId.toBase64url(),
-            authenticatorAssertionResponse =
-            com.linecorp.webauthn.model.AuthenticatorAssertionResponse(
-                clientDataJSON = clientDataJSON,
-                authenticatorData = authGetAssertionResult.authenticatorData,
-                signature = authGetAssertionResult.signature,
-                userHandle = authGetAssertionResult.userHandle,
-            ),
-            clientExtensionsOutput = options.extensions?.processClientExtensionsOutput(),
-        )
+            return PublicKeyCredentialGetResult(
+                id = authGetAssertionResult.credentialId.toBase64url(),
+                authenticatorAssertionResponse =
+                com.linecorp.webauthn.model.AuthenticatorAssertionResponse(
+                    clientDataJSON = clientDataJSON,
+                    authenticatorData = authGetAssertionResult.authenticatorData,
+                    signature = authGetAssertionResult.signature,
+                    userHandle = authGetAssertionResult.userHandle,
+                ),
+                clientExtensionsOutput = options.extensions?.processClientExtensionsOutput(),
+            )
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            // Mirror publicKeyCredentialCreate: normalize everything to WebAuthnException
+            // so get() never surfaces raw platform exceptions.
+            if (e is WebAuthnException) {
+                throw e
+            } else {
+                throw WebAuthnException.UnknownException(
+                    "Error occurred while getting public key credential: $e",
+                    e
+                )
+            }
+        }
     }
 
     /**

--- a/webauthn/src/main/java/com/linecorp/webauthn/rp/RelyingParty.kt
+++ b/webauthn/src/main/java/com/linecorp/webauthn/rp/RelyingParty.kt
@@ -78,6 +78,11 @@ data class AuthenticationOptions(val userVerification: UserVerificationRequireme
 data class RegistrationData(
     val attestation: AttestationConveyancePreference,
     val authenticatorSelection: AuthenticatorSelectionCriteria?,
+    /**
+     * MUST be the base64url (unpadded) encoding of the server's raw challenge bytes.
+     * The value is embedded verbatim as `challenge` in clientDataJSON and compared by
+     * the server during verification, so any other encoding will fail server-side.
+     */
     val challenge: String,
     val excludeCredentials: List<PublicKeyCredentialDescriptor>?,
     val extensions: ClientExtensionInput?,
@@ -88,6 +93,10 @@ data class RegistrationData(
 
 data class AuthenticationData(
     val allowCredentials: List<PublicKeyCredentialDescriptor>?,
+    /**
+     * MUST be the base64url (unpadded) encoding of the server's raw challenge bytes.
+     * See [RegistrationData.challenge].
+     */
     val challenge: String,
     val extensions: ClientExtensionInput?,
     val rpId: String,

--- a/webauthn/src/main/java/com/linecorp/webauthn/util/Fido2Util.kt
+++ b/webauthn/src/main/java/com/linecorp/webauthn/util/Fido2Util.kt
@@ -30,18 +30,27 @@ import java.security.cert.X509Certificate
 
 class Fido2Util {
     companion object {
+        /**
+         * Computes the FIDO AppID/Facet identifier for this package from its FIRST signing
+         * certificate, matching the facet spec's convention. Note: packages signed by
+         * multiple signers or using key rotation may need a server-side allowlist of all
+         * facet ids derived from each certificate.
+         */
         fun getPackageFacetID(context: Context): String {
-            val cert: ByteArray = if (Build.VERSION.SDK_INT >= 33) {
+            val signingInfo = if (Build.VERSION.SDK_INT >= 33) {
                 context.packageManager.getPackageInfo(
                     context.packageName,
                     PackageManager.PackageInfoFlags.of(PackageManager.GET_SIGNING_CERTIFICATES.toLong())
-                ).signingInfo!!.apkContentsSigners[0].toByteArray()
+                ).signingInfo
             } else {
                 context.packageManager.getPackageInfo(
                     context.packageName,
                     PackageManager.GET_SIGNING_CERTIFICATES
-                ).signingInfo!!.apkContentsSigners[0].toByteArray()
-            }
+                ).signingInfo
+            } ?: throw WebAuthnException.UtilityException(
+                "Cannot obtain signing info for package ${context.packageName}."
+            )
+            val cert: ByteArray = signingInfo.apkContentsSigners[0].toByteArray()
             val input: InputStream = ByteArrayInputStream(cert)
             val cf = CertificateFactory.getInstance("X509")
             val certificate: X509Certificate = cf.generateCertificate(input) as X509Certificate

--- a/webauthn/src/test/java/com/linecorp/webauthn/AuthenticatorTest.kt
+++ b/webauthn/src/test/java/com/linecorp/webauthn/AuthenticatorTest.kt
@@ -51,7 +51,13 @@ import java.security.KeyPairGenerator
 import java.security.Signature
 import java.security.cert.X509Certificate
 import kotlin.reflect.KClass
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeoutOrNull
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions
@@ -257,6 +263,59 @@ class AuthenticatorTest {
                 "makeCredential throws $e"
             )
         }
+    }
+
+    @Test
+    fun `cleanup runs when the job is cancelled while the key is being generated`(): Unit = runBlocking {
+        // Regression guard: a key committed to the KeyStore during a cancelled keygen must
+        // still be deleted. cryptoDispatcher must differ from the caller's context so
+        // withContext's prompt-cancellation guarantee applies.
+        val localAuthenticator = Authenticator(
+            db = mockFido2Database,
+            authenticationHandler = mockAuthenticationHandler,
+            fido2KeyGenerator = mockKeyGenerator,
+            fido2ObjectGenerator = mockObjectGenerator,
+            authType = AuthenticatorType.BiometricAndroidKey,
+            cryptoDispatcher = Dispatchers.Default,
+        )
+
+        val deletedAlias = CompletableDeferred<String>()
+        every { SecureExecutionHelper.deleteKey(any()) } answers {
+            deletedAlias.complete(firstArg())
+            Unit
+        }
+
+        lateinit var job: Job
+        // The key generator "creates" the key and then cancels the calling job, so that
+        // withContext resumes the caller with CancellationException even though the key
+        // was committed. With the flag set inside the block, cleanup must still run.
+        every { mockKeyGenerator.generateFido2Key(any(), any(), any(), any()) } answers {
+            job.cancel()
+            dummyKeyPair
+        }
+
+        job = launch(Dispatchers.Default, start = CoroutineStart.LAZY) {
+            try {
+                localAuthenticator.makeCredential(
+                    mockActivity,
+                    dummyHash,
+                    dummyRpEntity,
+                    dummyUserEntity,
+                    listOf(es256CredParams),
+                    null,
+                    null
+                )
+            } catch (_: Exception) {
+                // CancellationException is expected; swallow so the test can assert cleanup.
+            }
+        }
+        job.start()
+        job.join()
+
+        assertThat(withTimeoutOrNull(2000) { deletedAlias.await() }).isNotNull()
+
+        // Restore the shared stub for subsequent tests.
+        every { mockKeyGenerator.generateFido2Key(any(), any(), any(), any()) } returns dummyKeyPair
     }
 
     @Test

--- a/webauthn/src/test/java/com/linecorp/webauthn/model/AttestationObjectTest.kt
+++ b/webauthn/src/test/java/com/linecorp/webauthn/model/AttestationObjectTest.kt
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2024 LY Corporation
+ *
+ * LY Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.webauthn.model
+
+import co.nstant.`in`.cbor.CborDecoder
+import co.nstant.`in`.cbor.model.ByteString
+import co.nstant.`in`.cbor.model.UnicodeString
+import com.google.common.truth.Truth.assertThat
+import java.io.ByteArrayInputStream
+import org.junit.jupiter.api.Test
+import co.nstant.`in`.cbor.model.Map as CborMap
+
+class AttestationObjectTest {
+
+    @Test
+    fun `android-key attestation object and its nested attStmt are definite-length maps`() {
+        val authData = ByteArray(37) { it.toByte() }
+        val attStmt = AndroidKeyAttestationStatement(
+            alg = -7L,
+            sig = byteArrayOf(1, 2, 3),
+            x5c = listOf(byteArrayOf(4, 5, 6)),
+        )
+        val attestationObject = AttestationObject(authData, AttestationStatementFormat.ANDROID_KEY.value, attStmt)
+
+        val cbor = attestationObject.toCBOR()
+        val outerMap = CborDecoder(ByteArrayInputStream(cbor)).decode()[0] as CborMap
+
+        // Indefinite-length (chunked) maps violate the CTAP2 canonical CBOR encoding form.
+        assertThat(outerMap.isChunked).isFalse()
+        assertThat((outerMap.get(UnicodeString("authData")) as ByteString).bytes).isEqualTo(authData)
+        assertThat((outerMap.get(UnicodeString("fmt")) as UnicodeString).string)
+            .isEqualTo(AttestationStatementFormat.ANDROID_KEY.value)
+
+        val nestedAttStmt = outerMap.get(UnicodeString("attStmt")) as CborMap
+        assertThat(nestedAttStmt.isChunked).isFalse()
+        assertThat((nestedAttStmt.get(UnicodeString("sig")) as ByteString).bytes).isEqualTo(byteArrayOf(1, 2, 3))
+    }
+
+    @Test
+    fun `none attestation object encodes an empty definite-length attStmt map`() {
+        val attestationObject = AttestationObject(
+            ByteArray(1),
+            AttestationStatementFormat.NONE.value,
+            NoneAttestationStatement(),
+        )
+
+        val cbor = attestationObject.toCBOR()
+        val outerMap = CborDecoder(ByteArrayInputStream(cbor)).decode()[0] as CborMap
+
+        assertThat(outerMap.isChunked).isFalse()
+
+        val nestedAttStmt = outerMap.get(UnicodeString("attStmt")) as CborMap
+        assertThat(nestedAttStmt.isChunked).isFalse()
+        assertThat(nestedAttStmt.keys).isEmpty()
+    }
+}

--- a/webauthn/src/test/java/com/linecorp/webauthn/model/COSEAlgorithmIdentifierTest.kt
+++ b/webauthn/src/test/java/com/linecorp/webauthn/model/COSEAlgorithmIdentifierTest.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2024 LY Corporation
+ *
+ * LY Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.webauthn.model
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.Test
+
+class COSEAlgorithmIdentifierTest {
+
+    @Test
+    fun `values match the IANA COSE Algorithms registry`() {
+        assertThat(COSEAlgorithmIdentifier.RS1.value).isEqualTo(-65535L)
+        assertThat(COSEAlgorithmIdentifier.RS256.value).isEqualTo(-257L)
+        assertThat(COSEAlgorithmIdentifier.RS384.value).isEqualTo(-258L)
+        assertThat(COSEAlgorithmIdentifier.RS512.value).isEqualTo(-259L)
+        assertThat(COSEAlgorithmIdentifier.PS256.value).isEqualTo(-37L)
+        assertThat(COSEAlgorithmIdentifier.PS384.value).isEqualTo(-38L)
+        assertThat(COSEAlgorithmIdentifier.PS512.value).isEqualTo(-39L)
+        assertThat(COSEAlgorithmIdentifier.EdDSA.value).isEqualTo(-8L)
+        assertThat(COSEAlgorithmIdentifier.ES256.value).isEqualTo(-7L)
+        assertThat(COSEAlgorithmIdentifier.ES384.value).isEqualTo(-35L)
+        assertThat(COSEAlgorithmIdentifier.ES512.value).isEqualTo(-36L)
+        // RFC 8812 / IANA COSE Algorithms registry: ES256K is -47, not -43.
+        assertThat(COSEAlgorithmIdentifier.ES256K.value).isEqualTo(-47L)
+    }
+
+    @Test
+    fun `fromValue resolves every entry by its registered value`() {
+        COSEAlgorithmIdentifier.entries.forEach {
+            assertThat(COSEAlgorithmIdentifier.fromValue(it.value)).isEqualTo(it)
+        }
+    }
+
+    @Test
+    fun `fromValue returns null for the old incorrect ES256K value`() {
+        assertThat(COSEAlgorithmIdentifier.fromValue(-43L)).isNull()
+    }
+}

--- a/webauthn/src/test/java/com/linecorp/webauthn/model/COSEAlgorithmIdentifierTest.kt
+++ b/webauthn/src/test/java/com/linecorp/webauthn/model/COSEAlgorithmIdentifierTest.kt
@@ -34,7 +34,6 @@ class COSEAlgorithmIdentifierTest {
         assertThat(COSEAlgorithmIdentifier.ES256.value).isEqualTo(-7L)
         assertThat(COSEAlgorithmIdentifier.ES384.value).isEqualTo(-35L)
         assertThat(COSEAlgorithmIdentifier.ES512.value).isEqualTo(-36L)
-        // RFC 8812 / IANA COSE Algorithms registry: ES256K is -47, not -43.
         assertThat(COSEAlgorithmIdentifier.ES256K.value).isEqualTo(-47L)
     }
 
@@ -43,10 +42,5 @@ class COSEAlgorithmIdentifierTest {
         COSEAlgorithmIdentifier.entries.forEach {
             assertThat(COSEAlgorithmIdentifier.fromValue(it.value)).isEqualTo(it)
         }
-    }
-
-    @Test
-    fun `fromValue returns null for the old incorrect ES256K value`() {
-        assertThat(COSEAlgorithmIdentifier.fromValue(-43L)).isNull()
     }
 }

--- a/webauthn/src/test/java/com/linecorp/webauthn/model/EC2COSEKeyTest.kt
+++ b/webauthn/src/test/java/com/linecorp/webauthn/model/EC2COSEKeyTest.kt
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2024 LY Corporation
+ *
+ * LY Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.webauthn.model
+
+import co.nstant.`in`.cbor.CborDecoder
+import co.nstant.`in`.cbor.model.ByteString
+import co.nstant.`in`.cbor.model.NegativeInteger
+import com.google.common.truth.Truth.assertThat
+import java.io.ByteArrayInputStream
+import java.math.BigInteger
+import java.security.AlgorithmParameters
+import java.security.interfaces.ECPublicKey
+import java.security.spec.ECGenParameterSpec
+import java.security.spec.ECParameterSpec
+import java.security.spec.ECPoint
+import org.junit.jupiter.api.Test
+import co.nstant.`in`.cbor.model.Map as CborMap
+
+class EC2COSEKeyTest {
+
+    private fun fakeEcPublicKey(x: BigInteger, y: BigInteger): ECPublicKey {
+        val parameterSpec = AlgorithmParameters.getInstance("EC").apply {
+            init(ECGenParameterSpec("secp256r1"))
+        }.getParameterSpec(ECParameterSpec::class.java)
+
+        return object : ECPublicKey {
+            override fun getAlgorithm(): String = "EC"
+            override fun getFormat(): String = "X.509"
+            override fun getEncoded(): ByteArray = ByteArray(0)
+            override fun getParams(): ECParameterSpec = parameterSpec
+            override fun getW(): ECPoint = ECPoint(x, y)
+        }
+    }
+
+    private fun decodeCoordinates(cbor: ByteArray): Pair<ByteArray, ByteArray> {
+        val map = CborDecoder(ByteArrayInputStream(cbor)).decode()[0] as CborMap
+        val x = (map.get(NegativeInteger(-2)) as ByteString).bytes
+        val y = (map.get(NegativeInteger(-3)) as ByteString).bytes
+        return Pair(x, y)
+    }
+
+    @Test
+    fun `coordinate with top bit set is encoded as exactly 32 bytes`() {
+        // BigInteger.toByteArray() would return 33 bytes (0x00 sign byte) for this value.
+        val topBitSet = BigInteger(1, ByteArray(32) { 0xFF.toByte() })
+        val cbor = EC2COSEKey(fakeEcPublicKey(topBitSet, topBitSet)).toCBOR()
+
+        val (x, y) = decodeCoordinates(cbor)
+        assertThat(x).hasLength(32)
+        assertThat(y).hasLength(32)
+        assertThat(x).isEqualTo(ByteArray(32) { 0xFF.toByte() })
+    }
+
+    @Test
+    fun `coordinate with leading zero octets is padded to exactly 32 bytes`() {
+        // BigInteger.toByteArray() would return a single byte for this value.
+        val small = BigInteger.ONE
+        val cbor = EC2COSEKey(fakeEcPublicKey(small, small)).toCBOR()
+
+        val (x, y) = decodeCoordinates(cbor)
+        assertThat(x).hasLength(32)
+        assertThat(y).hasLength(32)
+        assertThat(x[31]).isEqualTo(1.toByte())
+        assertThat(x.copyOfRange(0, 31)).isEqualTo(ByteArray(31))
+    }
+
+    @Test
+    fun `cose key is encoded as a definite-length map`() {
+        val value = BigInteger(1, ByteArray(32) { 0x42 })
+        val cbor = EC2COSEKey(fakeEcPublicKey(value, value)).toCBOR()
+
+        // A definite-length CBOR map with 5 entries starts with 0xA5.
+        // The indefinite-length form (0xBF) violates the CTAP2 canonical encoding.
+        assertThat(cbor[0]).isEqualTo(0xA5.toByte())
+    }
+}


### PR DESCRIPTION
## Summary

Bumps the library to 1.2.0 with two kinds of change:

- **Production fixes**: issues seen in real error logs (biometric cancellation logged as a failure, older devices rejected without a clear reason, key generation failing on some StrongBox implementations).
- **Correctness fixes**: around the WebAuthn wire format, coroutine cancellation, and account/key cleanup.

All public API changes are additive; there are no breaking changes.

## What changed and why

### WebAuthn wire format

| Change | Reason |
| --- | --- |
| Encode COSE EC2 `x`/`y` as fixed-length 32-byte field elements | `BigInteger.toByteArray()` produced 33- or <32-byte values (a leading sign byte, or stripped leading zeros), which strict server stacks reject. This is the `credentialPublicKey` in the attestation object. |
| Emit definite-length CBOR maps for `attestationObject` / `credentialPublicKey` | `CborBuilder().startMap()` produced indefinite-length maps, which are not valid CTAP2 canonical CBOR. Switched to `addMap()` / `putMap()`. |

Both only affect the attestation object produced at registration; the assertion output is unchanged.

### Key generation and cleanup

| Change | Reason |
| --- | --- |
| Fix `cleanup()` deleting a re-encoded alias | The key is stored under `credId`, but `cleanup()` re-encoded it with `toBase64url()` and deleted a non-existent alias, so failed or cancelled registrations left the private key in the KeyStore. |
| Fall back to TEE on `ProviderException` during key generation | Some StrongBox implementations reject a request with a plain `ProviderException` (KeyMint `UNIMPLEMENTED`) rather than `StrongBoxUnavailableException`, so the existing TEE fallback never ran and registration failed. |
| `deleteAllAccounts()` removes KeyStore keys, not just DB rows | Keys were left behind on account deletion. |
| `getAllAccounts()` returns each credential once | A nested authenticator-type loop over an unfiltered query returned every credential four times. |

### Coroutine cancellation and lifecycle

| Change | Reason |
| --- | --- |
| Propagate `CancellationException` instead of wrapping it | Broad `catch` blocks (including those around DB calls, where Kotlin's `CancellationException` is an `Exception` subtype) re-wrapped cancellation as `RpException` / `CredSrcStorageException`, so a cancelled scope reported a spurious error. |
| Set the key-created flag inside the `withContext` block | `withContext` discards its result and throws on cancellation, so a key generated just before cancellation was left uncleaned. |
| Run key generation and KeyStore access off the caller's dispatcher | These blocking calls ran on the caller's dispatcher (usually `Main`), which risks ANR. `BiometricPrompt` stays on `Main`. |
| Run `cleanup()` under `NonCancellable` | Stops a rollback from deleting the key but leaving the DB row (or the reverse) when cancelled midway. |
| Lifecycle (RESUMED) guard and continuation safety in the auth handlers | Showing `BiometricPrompt` while the Activity is not resumed could crash or hang; a missing `isActive` guard could resume the continuation twice; `cancelAuthentication()` now runs on the main thread. |
| Harden the API<30 `KeyguardManager` path | Added `invokeOnCancellation` (dismiss the confirmation UI, release the static callback), deliver the result once, and do not re-fire the confirmation when the Activity is re-created. |

### Diagnostics

| Change | Reason |
| --- | --- |
| Expose `errorCode` / `capabilityStatus` (with constant names) on exceptions | `NotAllowedException` lumped biometric cancellations and real failures into one type; `ConstraintException` lumped every `canAuthenticate()` reason into one. Callers could not tell them apart and logs had no actionable reason. |
| Add `PublicKeyCredential.canAuthenticate(context)` | Lets integrators check device capability up front instead of failing partway through a flow. |
| Keep `DeletionException.trigger` | The exception that caused a rollback was dropped; it is now kept and also attached as a suppressed exception. |

### Spec and correctness

| Change | Reason |
| --- | --- |
| Require a user gesture before returning `InvalidStateError` for `excludeCredentials` | Returning immediately let a relying party check whether a credential exists on the device with no user interaction (WebAuthn L2 section 6.3.2). |
| Pin the biometric prompt to `BIOMETRIC_STRONG` | Without `setAllowedAuthenticators` the no-CryptoObject path allowed Class 2 (weak) biometrics while still asserting user verification. |
| Validate `user.id` by decoded byte length (1..64) | It was checked by string length, which rejected valid 64-byte ids and pushed bad input to a later crash. |
| Match `allowCredentials` entries by `type` as well as `rpId` | `type` was ignored before. |
| Fix the `ES256K` COSE algorithm value (`-43` → `-47`) | The old value didn't match the COSE Algorithms registry (RFC 8812 / IANA), so a relying party validating the registered algorithm id would reject an `ES256K` credential. |
| Misc | Add `UserVerificationRequirement.DISCOURAGED`, fix the ES512 curve name (`secp521r1`), document the `challenge` encoding, and guard against null signing info. |

## Public API (additive)

- `PublicKeyCredential.canAuthenticate(context): Int`
- `NotAllowedException.errorCode` / `errorCodeName` / `isUserCancellation`
- `ConstraintException.capabilityStatus` / `capabilityStatusName`
- `DeletionException.trigger`
- `UserVerificationRequirement.DISCOURAGED`

Existing exception types and message prefixes are unchanged.

## Compatibility

Existing credentials keep working. The assertion output is identical to 1.1.3 (no COSE key or CBOR map is involved in an assertion), and nothing in the upgrade touches stored keys, DB rows, or the signature counter. No re-registration is needed.

## Testing

- Unit tests pass, including new tests for the COSE coordinate / definite-map encoding and for key cleanup when the job is cancelled during key generation.
- `ktlintCheck` and `assembleRelease` pass.
- On-device checks planned before merge: (1) register on 1.1.3, upgrade-install 1.2.0, and confirm authentication still works with a continuous signature counter; (2) confirm the server accepts the new attestation encoding for new registrations.

